### PR TITLE
Un-hardcodes some registers

### DIFF
--- a/V1724.cc
+++ b/V1724.cc
@@ -344,16 +344,17 @@ int V1724::ConfigureBaselines(vector <u_int16_t> &end_values,
 	  }
 	  idx += csize-2;
 	  // Toss if signal inside
-	  if(abs(maxval-minval>30)){
+	  if(abs((int)(maxval)-(int)(minval))>30){
 	    std::cout<<"Signal in baseline, channel "<<channel
 		     <<" min: "<<minval<<" max: "<<maxval<<std::endl;
 	  }
-	  else
-	    baseline = (float(tbase) / ((float(bcount))));
+	  else{
+	      baseline = (float(tbase) / ((float(bcount))));
 
-	  // Add to total
-	  baseline_per_channel[channel]+= baseline;
-	  good_triggers_per_channel[channel]+=1.;
+	      // Add to total
+	      baseline_per_channel[channel]+= baseline;
+	      good_triggers_per_channel[channel]+=1.;
+	  }
 	} // end for loop through channels
 	//delete[] buff;
 	//break;

--- a/V1724.hh
+++ b/V1724.hh
@@ -37,6 +37,7 @@ class V1724{
   int LoadDAC(vector<u_int16_t>dac_values, vector<bool> &update_dac);
   bool MonitorRegister(u_int32_t reg, u_int32_t mask, int ntries,
                        int sleep, u_int32_t val=1);
+  int fNsPerSample;
 
  private:
   Options *fOptions;
@@ -44,6 +45,14 @@ class V1724{
   int fLink, fCrate, fBID;
   unsigned int fBaseAddress;
   int fFirmwareVersion;
+
+  // Some values for base classes to override
+  int fAqCtrlRegister;
+  int fAqStatusRegister;
+  int fSwTrigRegister;
+  int fResetRegister;
+  int fChStatusRegister;
+  int fChDACRegister;
 
   // Stuff for clock reset tracking
   u_int32_t clock_counter;

--- a/main.cc
+++ b/main.cc
@@ -1,14 +1,26 @@
 #include <iostream>
 #include <string>
 #include <iomanip>
+#include <csignal>
 #include "V1724.hh"
 #include "DAQController.hh"
+
+bool b_run = true;
+
+void SignalHandler(int signum) {
+    std::cout << "Received signal "<<signum<<std::endl;
+    b_run = false;
+    return;
+}
 
 int main(int argc, char** argv){
 
   // Need to create a mongocxx instance and it must exist for
   // the entirety of the program. So here seems good.
   mongocxx::instance instance{};
+
+  signal(SIGINT, SignalHandler);
+  signal(SIGTERM, SignalHandler);
    
   std::string current_run_id="none";
   
@@ -61,7 +73,7 @@ int main(int argc, char** argv){
   
   // Main program loop. Scan the database and look for commands addressed
   // to this hostname. 
-  while(1){
+  while(b_run){
 
     // Try to poll for commands
     bsoncxx::stdx::optional<bsoncxx::document::value> querydoc;


### PR DESCRIPTION
To facilitate extending redax to work with digitizers other than the v1724 (and improve readability) the hard-coded register addresses were made member variables.

Anything relating to the number of channels has not been changed, and the code still assumes 8 channels.