### PR TITLE
V1495

### DIFF
--- a/CControl_Handler.cc
+++ b/CControl_Handler.cc
@@ -59,13 +59,13 @@ int CControl_Handler::DeviceArm(int run, Options *opts){
   fDDC10 = new DDC10();
 
   if(fOptions->GetHEVOpt(hopts, "DDC10") != 0){
-     fLog->Entry("Failed to pull DDC10 options from file", MongoLog::Error);
+     fLog->Entry(MongoLog::Error, "Failed to pull DDC10 options from file");
      fStatus = DAXHelpers::Idle;
      return -1;
   }
   // Initialise the DDC10 based HEV - it doesn't need further "start"/"stop" signals
   if(fDDC10->Initialize(hopts)!=0){
-    fLog->Entry("Failed to initialise DDC10 HEV", MongoLog::Error);
+    fLog->Entry(MongoLog::Error, "Failed to initialise DDC10 HEV");
     fStatus = DAXHelpers::Idle;
     return -1;
   }else{

--- a/CControl_Handler.hh
+++ b/CControl_Handler.hh
@@ -6,7 +6,6 @@
 #include "V2718.hh"
 #include <thread>
 
-class V1495;
 class DDC10;
 
 class CControl_Handler{
@@ -23,7 +22,6 @@ public:
 private:
 
   V2718 *fV2718;
-  V1495 *fV1495;
   DDC10 *fDDC10;
 
   int fStatus;

--- a/Options.cc
+++ b/Options.cc
@@ -215,7 +215,7 @@ int Options::GetCrateOpt(CrateOptions &ret, std::string device){
     try{
       // This only works if there's one v1495 in the system
       fLog->Entry(MongoLog::Local, "Getting V1495 options");
-      ret.v1495_vme_address = bson_options["V2718"]["V1495_vme_address"].get_int32().value;
+      ret.v1495_vme_address = bson_options["V2718"]["V1495_vme_address"].get_utf8().value.to_string();
       bsoncxx::array::view regs = bson_options["V2718"]["V1495_registers"].get_array().value;
       RegisterType rt;
       for (auto& reg : regs) {

--- a/Options.cc
+++ b/Options.cc
@@ -210,12 +210,28 @@ int Options::GetCrateOpt(CrateOptions &ret, std::string device){
     ret.muon_veto = bson_options["V2718"]["muon_veto"].get_int32().value;
     ret.neutron_veto = bson_options["V2718"]["neutron_veto"].get_int32().value;
     ret.led_trigger = bson_options["V2718"]["led_trigger"].get_int32().value;
+    try{
+      // This only works if there's one v1495 in the system
+      fLog->Entry(MongoLog::Local, "Getting V1495 options");
+      ret.v1495_vme_address = bson_options["V2718"]["V1495_vme_address"].get_int32().value;
+      bsoncxx::array::view regs = bson_options["V2718"]["V1495_registers"].get_array().value;
+      RegisterType rt;
+      for (auto& reg : regs) {
+        rt.reg = reg["reg"].get_utf8().value.to_string();
+        rt.val = reg["val"].get_utf8().value.to_string();
+        ret.v1495_registers.push_back(rt);
+      }
+      ret.has_v1495 = true;
+    }catch(std::exception &E) {
+      // document probably doesn't have V1495 entries
+      ret.has_v1495 = false;
+    }
   }catch(std::exception &E){
     std::cout<<"Exception getting ccontroller opts: "<<std::endl<<E.what()<<std::endl;
     return -1;
   }
   return 0;
-}	
+}
 
 int Options::GetChannel(int bid, int cid){
   std::string boardstring = std::to_string(bid);

--- a/Options.hh
+++ b/Options.hh
@@ -42,7 +42,7 @@ struct CrateOptions{
   int led_trigger;
   int s_in;
   bool has_v1495;
-  uint32_t v1495_vme_address;
+  std::string v1495_vme_address;
   std::vector<RegisterType> v1495_registers;
 };
 

--- a/Options.hh
+++ b/Options.hh
@@ -39,9 +39,10 @@ struct CrateOptions{
   int muon_veto;
   int led_trigger;
   int s_in;
+  bool has_v1495;
+  uint32_t v1495_vme_address;
+  std::vector<RegisterType> v1495_registers;
 };
-
-
 
 class Options{
 

--- a/V2718.cc
+++ b/V2718.cc
@@ -12,12 +12,12 @@ V2718::~V2718(){
 }
 
 
-int V2718::CrateInit(CrateOptions c_opts, int link, int crate, uint32_t vme_address){
+int V2718::CrateInit(CrateOptions c_opts, int link, int crate, std::string vme_address){
         
   fCrate = crate;
   fLink = link;  	
   fCopts = c_opts;
-  fVMEAddress = vme_address;
+  fVMEAddress = DAXHelpers::StringToHex(vme_address);
   // Initialising the V2718 module via the specified optical link
   int a = CAENVME_Init(cvV2718, fLink, fCrate, &fBoardHandle);
   if(a != cvSuccess){
@@ -28,7 +28,7 @@ int V2718::CrateInit(CrateOptions c_opts, int link, int crate, uint32_t vme_addr
   if (fCopts.has_v1495) {
     uint32_t addr, val;
     for (auto& reg_write : fCopts.v1495_registers) {
-      addr = fVMEAddress + fCopts.v1495_vme_address + DAXHelpers::StringToHex(reg_write.reg);
+      addr = fVMEAddress + DAXHelpers::StringToHex(fCopts.v1495_vme_address) + DAXHelpers::StringToHex(reg_write.reg);
       val = DAXHelpers::StringToHex(reg_write.val);
       a = CAENVME_WriteCycle(fCrate, addr, &val, cvA32_U_DATA, cvD32);
       if (a != cvSuccess) {

--- a/V2718.cc
+++ b/V2718.cc
@@ -12,11 +12,12 @@ V2718::~V2718(){
 }
 
 
-int V2718::CrateInit(CrateOptions c_opts, int link, int crate){
+int V2718::CrateInit(CrateOptions c_opts, int link, int crate, uint32_t vme_address){
         
   fCrate = crate;
   fLink = link;  	
   fCopts = c_opts;
+  fVMEAddress = vme_address;
   
   // Initialising the V2718 module via the specified optical link
   int a = CAENVME_Init(cvV2718, fLink, fCrate, &fBoardHandle);
@@ -25,6 +26,22 @@ int V2718::CrateInit(CrateOptions c_opts, int link, int crate){
     return -1;
   }   
   SendStopSignal(false);
+  if (fCopts.has_v1495) {
+    uint32_t addr, val;
+    for (auto& reg_write : fCopts.v1495_registers) {
+      addr = fVMEAddress + fCopts.v1495_vme_address + DAXHelpers::StringToHex(reg_write.reg);
+      val = DAXHelpers::StringToHex(reg_write.val);
+      a = CAENVME_WriteCycle(fCrate, addr, &val, cvA32_U_DATA, cvD32);
+      if (a != cvSuccess) {
+        std::stringstream msg;
+        msg << "Failed to write value 0x" << reg_write.val << " to V1495 address 0x"
+            << reg_write.reg << " (VME addr 0x" << fCopts.v1495_vme_address << ")";
+        fLog->Entry(MongoLog::Error, msg.str());
+        return -2;
+      }
+      usleep(1000);
+    }
+  }
   return 0;
 }
 

--- a/V2718.hh
+++ b/V2718.hh
@@ -14,15 +14,13 @@
 
 using namespace std;
 
-
-
 class V2718{
  
 public:
   V2718(MongoLog *log);
   ~V2718();
   
-  int CrateInit(CrateOptions c_opts, int link, int crate);
+  int CrateInit(CrateOptions c_opts, int link, int crate, uint32_t vme_address);
   int SendStartSignal();
   int SendStopSignal(bool end=true); 
   
@@ -34,6 +32,7 @@ private:
   
   int fBoardHandle;
   int fCrate, fLink;
+  uint32_t fVMEAddress;
   
   MongoLog *fLog;
 

--- a/V2718.hh
+++ b/V2718.hh
@@ -20,7 +20,7 @@ public:
   V2718(MongoLog *log);
   ~V2718();
   
-  int CrateInit(CrateOptions c_opts, int link, int crate, uint32_t vme_address);
+  int CrateInit(CrateOptions c_opts, int link, int crate, std::string vme_address);
   int SendStartSignal();
   int SendStopSignal(bool end=true); 
   


### PR DESCRIPTION
Adds support for runtime configuration of a V1495. This is achieved by having the V2718 make register writes to the VME address of the V1495 during initialization. As the V1495 isn't an "active" board in the same sense as the others, it doesn't need its own class, just a few extra options in the configs.