### PR TITLE
Baseline routine 2.0

### DIFF
--- a/DAQController.cc
+++ b/DAQController.cc
@@ -137,11 +137,10 @@ int DAQController::InitializeElectronics(Options *options, std::vector<int>&keys
 	BL_MODE = "fixed";
       }
       if(BL_MODE == "fixed"){
-	int BLVal = fOptions->GetInt("baseline_fixed_value", 4000);
+	int BLVal = fOptions->GetInt("baseline_fixed_value", 5300);
 	fLog->Entry(MongoLog::Local, "Loading fixed baselines at value 0x%04x for digi %i",
 		    BLVal, digi->bid());
-	for(unsigned int x=0;x<dac_values.size();x++)
-	  dac_values[x] = BLVal;
+    dac_values.assign(dac_values.size(), BLVal);
       }
 	
       //int success = 0;

--- a/MongoLog.cc
+++ b/MongoLog.cc
@@ -74,12 +74,15 @@ int MongoLog::Entry(int priority, std::string message, ...){
     }
   }
 
+  auto t = std::time(nullptr);
+  auto tm = *std::localtime(&t);
+  std::stringstream to_print;
+  to_print<<std::put_time(&tm, "%d-%m-%Y %H-%M-%S")<<" ["<<fPriorities[priority+1]
+	    <<"]: "<<message<<std::endl;
+  std::cout << to_print.str();
   if(fLocalFileLogging){
     // ALL priorities get written locally (add some sort of size control later!)
-    auto t = std::time(nullptr);
-    auto tm = *std::localtime(&t);
-    fOutfile<<std::put_time(&tm, "%d-%m-%Y %H-%M-%S")<<" ["<<fPriorities[priority+1]
-	    <<"]: "<<message<<std::endl;
+    fOutfile<<to_print.str();
   }
   
   return 0;

--- a/Options.cc
+++ b/Options.cc
@@ -168,7 +168,7 @@ std::vector<BoardType> Options::GetBoards(std::string type, std::string hostname
   
   for(bsoncxx::array::element ele : subarr){
     std::string btype = ele["type"].get_utf8().value.to_string();
-    if(std::count(types.begin(), types.end(), btype))
+    if(!std::count(types.begin(), types.end(), btype))
       continue;
     try{
       if(ele["host"].get_utf8().value.to_string() != hostname)

--- a/V1724.cc
+++ b/V1724.cc
@@ -1,4 +1,5 @@
 #include "V1724.hh"
+#include <numeric>
 
 
 V1724::V1724(MongoLog  *log, Options *options){
@@ -16,15 +17,15 @@ V1724::V1724(MongoLog  *log, Options *options){
   fChDACRegister = 0x1098;
 
   DataFormatDefinition = {
-    {"channel_mask_msb_idx", NULL},
-    {"channel_mask_msb_mask", NULL},
+    {"channel_mask_msb_idx", -1},
+    {"channel_mask_msb_mask", -1},
     {"channel_header_words", 2},
     {"ns_per_sample", 10},
     {"ns_per_clk", 10},
     // Channel indices are given relative to start of channel
     // i.e. the channel size is at index '0'
-    {"channel_time_msb_idx", NULL},
-    {"channel_time_msb_mask", NULL},
+    {"channel_time_msb_idx", -1},
+    {"channel_time_msb_mask", -1},
     
   };
   
@@ -386,7 +387,7 @@ int V1724::ConfigureBaselines(vector <u_int16_t> &end_values,
 
 	u_int32_t words_in_event = buff[idx]&0xFFFFFFF;
 	u_int32_t cmask = buff[idx+1]&0xFF;
-        if (DataFormatDefinition["channel_mask_msb_idx"] != NULL) {
+        if (DataFormatDefinition["channel_mask_msb_idx"] != -1) {
           // fill in the v1730 stuff here
         }
 	u_int32_t channel_words = 0;

--- a/V1724.hh
+++ b/V1724.hh
@@ -57,6 +57,7 @@ protected:
   int fResetRegister;
   int fChStatusRegister;
   int fChDACRegister;
+  int fNChannels;
 
 private:
 

--- a/V1724.hh
+++ b/V1724.hh
@@ -51,13 +51,13 @@ class V1724{
 
 protected:
   // Some values for base classes to override 
-  int fAqCtrlRegister;
-  int fAqStatusRegister;
-  int fSwTrigRegister;
-  int fResetRegister;
-  int fChStatusRegister;
-  int fChDACRegister;
-  int fNChannels;
+  unsigned int fAqCtrlRegister;
+  unsigned int fAqStatusRegister;
+  unsigned int fSwTrigRegister;
+  unsigned int fResetRegister;
+  unsigned int fChStatusRegister;
+  unsigned int fChDACRegister;
+  unsigned int fNChannels;
 
 private:
 

--- a/V1724_MV.cc
+++ b/V1724_MV.cc
@@ -2,7 +2,7 @@
 
 V1724_MV::V1724_MV(MongoLog *log, Options *options)
   :V1724(log, options){
-  DataFormatDefinition["channel_header_size"] = 0;
+  DataFormatDefinition["channel_header_words"] = 0;
 }
 
 V1724_MV::~V1724_MV(){};


### PR DESCRIPTION
Overhauls the baseline routine. Baselines are calculated via a histogram, rather than a simple average, which should allow it to work even in the presence of a transient signal. Starts with a 3-point calibration, then uses this to begin the fitting routine very close to the desired baseline value (usually within 0.1%). Also makes some minor changes to the logging (always prints to console now), and changes a few variable names for clarity. Converges more quickly than the previous algorithm.