### PR TITLE
Parallel board programming

### DIFF
--- a/DAQController.cc
+++ b/DAQController.cc
@@ -110,7 +110,7 @@ int DAQController::InitializeElectronics(Options *options, std::vector<int>&keys
     this_thread::sleep_for(100ms);
   }
 
-  for (i = 0; i < init_threads.size() i++) {
+  for (i = 0; i < init_threads.size(); i++) {
     init_threads[i]->join();
     delete init_threads[i];
     written_dacs.merge(dacs[i]);

--- a/DAQController.hh
+++ b/DAQController.hh
@@ -10,7 +10,6 @@
 
 struct processingThread{
   std::thread *pthread;
-  //MongoInserter *inserter;
   StraxInserter *inserter;
 };
 
@@ -56,20 +55,19 @@ public:
   
 private:
   void AppendData(vector<data_packet> &d);
-  void LinkInit(vector<V1724*>& digis, map<int, vector<u_int16_t>>& dacs, atomic_int& ret);
+  void InitLink(vector<V1724*>&, map<int, vector<u_int16_t>>&, int&);
   
   std::vector <processingThread> fProcessingThreads;  
   std::map<int, std::vector <V1724*>> fDigitizers;
   std::mutex fBufferMutex;
-  MongoLog *fLog;
   
   bool fReadLoop;
-  Options *fOptions;
-  DAXHelpers *fHelper;
   std::vector<data_packet> *fRawDataBuffer;
   int fStatus;
   int fNProcessingThreads;
   string fHostname;
+  MongoLog *fLog;
+  Options *fOptions;
   
   // For reporting to frontend
   u_int64_t fBufferLength;

--- a/DAQController.hh
+++ b/DAQController.hh
@@ -56,6 +56,7 @@ public:
   
 private:
   void AppendData(vector<data_packet> &d);
+  void LinkInit(vector<V1724*>& digis, map<int, vector<u_int16_t>>& dacs, atomic_int& ret);
   
   std::vector <processingThread> fProcessingThreads;  
   std::map<int, std::vector <V1724*>> fDigitizers;

--- a/MongoLog.cc
+++ b/MongoLog.cc
@@ -78,8 +78,10 @@ int MongoLog::Entry(int priority, std::string message, ...){
     // ALL priorities get written locally (add some sort of size control later!)
     auto t = std::time(nullptr);
     auto tm = *std::localtime(&t);
+    fMutex.lock();
     fOutfile<<std::put_time(&tm, "%d-%m-%Y %H-%M-%S")<<" ["<<fPriorities[priority+1]
 	    <<"]: "<<message<<std::endl;
+    fMutex.unlock();
   }
   
   return 0;

--- a/MongoLog.cc
+++ b/MongoLog.cc
@@ -65,7 +65,7 @@ int MongoLog::Entry(int priority, std::string message, ...){
 				  "message" << message <<
 				  "priority" << priority <<
 				  bsoncxx::builder::stream::finalize);
-      std::cout<<"("<<priority<<"): "<<message<<std::endl;
+      //std::cout<<"("<<priority<<"): "<<message<<std::endl;
     }
     catch(const std::exception &e){
       std::cout<<"Failed to insert log message "<<message<<" ("<<
@@ -74,15 +74,17 @@ int MongoLog::Entry(int priority, std::string message, ...){
     }
   }
 
+  auto t = std::time(nullptr);
+  auto tm = *std::localtime(&t);
   if(fLocalFileLogging){
     // ALL priorities get written locally (add some sort of size control later!)
-    auto t = std::time(nullptr);
-    auto tm = *std::localtime(&t);
     fMutex.lock();
-    fOutfile<<std::put_time(&tm, "%d-%m-%Y %H-%M-%S")<<" ["<<fPriorities[priority+1]
+    fOutfile<<std::put_time(&tm, "%Y-%m-%d %H-%M-%S")<<" ["<<fPriorities[priority+1]
 	    <<"]: "<<message<<std::endl;
     fMutex.unlock();
   }
+  std::cout<<std::put_time(&tm, "%Y-%m-%d %H-%M-%S")<<" ["<<fPriorities[priority+1]
+	    <<"]: "<<message<<std::endl;
   
   return 0;
 }

--- a/MongoLog.hh
+++ b/MongoLog.hh
@@ -9,6 +9,7 @@
 #include <iomanip>
 #include <cstdarg>
 #include <cstring>
+#include <mutex>
 
 #include <mongocxx/client.hpp>
 #include <mongocxx/uri.hpp>
@@ -84,6 +85,7 @@ private:
   std::string fHostname;
   int fLogLevel;
   bool fLocalFileLogging;
+  std::mutex fMutex;
 };
 
 #endif


### PR DESCRIPTION
Wraps the digitizer baselining and register loading into a separate function, which allows links to be programmed separately and in parallel. Should help speed up the arming sequence on machines with multiple links. Additionally, wraps the logfile writing with a mutex to prevent possible access issues.

Full-scale testing should probably wait until after #35 gets merged, as the baselining routine (what this PR is largely aimed at) on master will probably immediately crash the readers.