### PR TITLE
Logfile rotator

### DIFF
--- a/MongoLog.cc
+++ b/MongoLog.cc
@@ -1,21 +1,56 @@
 #include "MongoLog.hh"
 
-MongoLog::MongoLog(bool LocalFileLogging){
+MongoLog::MongoLog(bool LocalFileLogging, int DeleteAfterDays){
   fLogLevel = 0;
   fHostname = "_host_not_set";
+  fLogFileNameFormat = "%Y%m%d.log";
+  fDeleteAfterDays = DeleteAfterDays;
 
   if(LocalFileLogging){
-    std::cout<<"Configured WITH local file logging. See DAQLog.log"<<std::endl;
-    fOutfile.open("DAQLog.log", std::ofstream::out | std::ofstream::app);
-    auto t = std::time(nullptr);
-    auto tm = *std::localtime(&t);
-    fOutfile<<std::put_time(&tm, "%d-%m-%Y %H-%M-%S")<<
-      " [INIT]: File initialized"<<std::endl;
+    std::cout<<"Configured WITH local file logging."<<std::endl;
+    RotateLogFile();
   }
   fLocalFileLogging = LocalFileLogging;
 }
 MongoLog::~MongoLog(){
   fOutfile.close();
+}
+
+std::string MongoLog::FormatTime(struct tm* date) {
+    return std::string(std::put_time(date, "%F %T"));
+}
+
+int MongoLog::Today(struct tm* date) {
+    return std::stoi(std::put_time(date, "%Y%m%d"));
+}
+
+int MongoLog::RotateLogFile() {
+    if (fOutfile.is_open()) fOutfile.close();
+    auto t = std::time(0);
+    auto today = *std::gmtime(&t);
+    std::string fn = std::put_time(&today, fLogFileNameFormat.c_str());
+    fOutfile.open(fn, std::ofstream::out | std::ofstream::app);
+    if (!fOutfile.is_open()) {
+        std::cout << "Could not rotate logfile!\n";
+        return -1;
+    }
+    fOutfile << FormatTime(&today) << " [INIT]: logfile initialized\n";
+    fToday = Today(&today);
+    std::array<int, 12> days_per_month = {31,28,31,30,31,30,31,31,30,31,30,31};
+    if (tm.tm_year%4 == 0) days_per_month[1] += 1; // the edge-case is SEP
+    struct tm last_week = today;
+    last_week.tm_mday -= fDeleteAfterDays;
+    if (last_week.tm_mday <= 0) { // new month
+        last_week.tm_mon--;
+        if (last_week.tm_mon < 0) { // new year
+            last_week.tm_year--;
+            last_week.tm_mon = 11;
+        }
+        last_week.tm_mday += days_per_month[last_week.tm_mon]; // off by one error???
+    }
+    std::string last_weeks_log = std::put_time(&last_week, fLogFileNameFormat.c_str());
+    std::filesystem::path p = last_weeks_log;
+    if (std::filesystem::exists(last_weeks_log)) std::filesystem::remove(last_weeks_log);
 }
 
 int  MongoLog::Initialize(std::string connection_string,
@@ -35,7 +70,7 @@ int  MongoLog::Initialize(std::string connection_string,
   }
 
   fHostname = host;
-  
+
   if(debug)
     fLogLevel = 1;
   else
@@ -75,18 +110,18 @@ int MongoLog::Entry(int priority, std::string message, ...){
   }
 
   auto t = std::time(nullptr);
-  auto tm = *std::localtime(&t);
-  std::stringstream to_print;
-  to_print<<std::put_time(&tm, "%Y-%m-%d %H-%M-%S")<<" ["<<fPriorities[priority+1]
+  auto tm = *std::gmtime(&t);
+  std::stringstream msg;
+  msg<<std::FormatTime(&tm)<<" ["<<fPriorities[priority+1]
 	    <<"]: "<<message<<std::endl;
-  std::cout << to_print.str();
+  std::cout << msg.str();
   if(fLocalFileLogging){
-    // ALL priorities get written locally (add some sort of size control later!)
     fMutex.lock();
-    fOutfile<<to_print.str();
+    if (Today(&tm) != fToday) RotateLogFile();
+    fOutfile<<msg.str();
     fMutex.unlock();
   }
-  
+
   return 0;
 }
 
@@ -127,7 +162,7 @@ int MongoLog::GetDACValues(int bid, int reference_run,
     res = (*doc).view();
 
     try{
-      // Make sure key exists before loading                                                               
+      // Make sure key exists before loading
       if(res.find(std::to_string(bid)) != res.end()){
 	dac_values.clear();
 	bsoncxx::array::view channel_arr = res[std::to_string(bid)].get_array().value;
@@ -151,7 +186,7 @@ int MongoLog::GetDACValues(int bid, int reference_run,
     res = *doc;
     
     try{
-      // Make sure key exists before loading                                                               
+      // Make sure key exists before loading
       if(res.find(std::to_string(bid)) != res.end()){
 	dac_values.clear();
 	bsoncxx::array::view channel_arr = res[std::to_string(bid)].get_array().value;

--- a/MongoLog.cc
+++ b/MongoLog.cc
@@ -56,7 +56,13 @@ int MongoLog::RotateLogFile() {
   std::stringstream s;
   s << std::put_time(&last_week, fLogFileNameFormat.c_str());
   std::experimental::filesystem::path p = s.str();
-  if (std::experimental::filesystem::exists(p)) std::experimental::filesystem::remove(p);
+  if (std::experimental::filesystem::exists(p)) {
+    fOutfile << FormatTime(&today) << " [INIT]: Deleting " << p << '\n';
+    std::experimental::filesystem::remove(p);
+  }
+  else {
+    fOutfile << FormatTime(&today) << " [INIT]: No older logfile to delete :(\n";
+  }
   return 0;
 }
 

--- a/MongoLog.hh
+++ b/MongoLog.hh
@@ -79,6 +79,7 @@ public:
 private:
   std::string FormatTime(struct tm* date);
   int Today(struct tm* date);
+  int RotateLogFile();
   std::vector<std::string> fPriorities{"LOCAL", "DEBUG", "MESSAGE",
       "WARNING", "ERROR", "FATAL"};
   std::ofstream fOutfile; 

--- a/MongoLog.hh
+++ b/MongoLog.hh
@@ -53,7 +53,7 @@ class MongoLog{
   */
   
 public:
-  MongoLog(bool LocalFileLogging=false);
+  MongoLog(bool LocalFileLogging=false, int DeleteAfterDays=7);
   ~MongoLog();
   
   int  Initialize(std::string connection_string,
@@ -77,14 +77,19 @@ public:
 			 std::map<int, std::vector<u_int16_t>>dac_values);
 
 private:
+  std::string FormatTime(struct tm* date);
+  int Today(struct tm* date);
   std::vector<std::string> fPriorities{"LOCAL", "DEBUG", "MESSAGE",
       "WARNING", "ERROR", "FATAL"};
   std::ofstream fOutfile; 
   mongocxx::client fMongoClient;
   mongocxx::collection fMongoCollection, fDAC_collection;
   std::string fHostname;
+  std::string fLogFileNameFormat;
   int fLogLevel;
   bool fLocalFileLogging;
+  int fDeleteAfterDays;
+  int fToday;
   std::mutex fMutex;
 };
 


### PR DESCRIPTION
Adds a logfile that rotates every night at midnight UTC. Also deletes logfiles older than a specified number of days (currently set to 7, and will likely never be changed).