### PR TITLE
Header cleanup

### DIFF
--- a/CControl_Handler.cc
+++ b/CControl_Handler.cc
@@ -1,5 +1,11 @@
 #include "CControl_Handler.hh"
 #include "DAXHelpers.hh"
+#include "Options.hh"
+#include "MongoLog.hh"
+#include "V2718.hh"
+#include "DDC10.hh"
+//#include "V1495.hh"
+#include <vector>
 
 CControl_Handler::CControl_Handler(MongoLog *log, std::string procname){
   fOptions = NULL;

--- a/CControl_Handler.hh
+++ b/CControl_Handler.hh
@@ -1,13 +1,15 @@
 #ifndef _CCONTROL_HANDLER_HH_
 #define _CCONTROL_HANDLER_HH_
 
-#include "Options.hh"
-#include "MongoLog.hh"
-#include "V2718.hh"
-#include "DDC10.hh"
-#include <thread>
+#include <string>
+#include <bsoncxx/document/value.hpp>
 
+class MongoLog;
+class Options;
+class V2718;
+class DDC10;
 class V1495;
+
 class CControl_Handler{
   
 public:

--- a/DAQController.hh
+++ b/DAQController.hh
@@ -3,10 +3,17 @@
 
 #include <thread>
 #include <atomic>
-#include "V1724_MV.hh"
-#include "DAXHelpers.hh"
-#include "Options.hh"
-#include "StraxInserter.hh"
+#include <string>
+#include <map>
+#include <vector>
+#include <cstdint>
+#include <mutex>
+
+class StraxInserter;
+class MongoLog;
+class Options;
+class V1724;
+class data_packet;
 
 struct processingThread{
   std::thread *pthread;
@@ -32,7 +39,7 @@ public:
   int buffer_length(){
     return fBufferLength;
   };
-  std::string run_mode();    
+  std::string run_mode();
   
   int Start();
   int Stop();
@@ -54,27 +61,26 @@ public:
   std::map<std::string, int> GetDataFormat();
   
 private:
-  void AppendData(vector<data_packet> &d);
-  void InitLink(vector<V1724*>&, map<int, vector<u_int16_t>>&, int&);
-  
+  void AppendData(std::vector<data_packet> &d);
+  void InitLink(std::vector<V1724*>&, std::map<int, std::vector<u_int16_t>>&, int&);
+
   std::vector <processingThread> fProcessingThreads;  
   std::map<int, std::vector <V1724*>> fDigitizers;
   std::mutex fBufferMutex;
-  
+
   bool fReadLoop;
   std::vector<data_packet> *fRawDataBuffer;
   int fStatus;
   int fNProcessingThreads;
-  string fHostname;
+  std::string fHostname;
   MongoLog *fLog;
   Options *fOptions;
-  
+
   // For reporting to frontend
   u_int64_t fBufferLength;
   u_int64_t fDatasize;
   std::map<int, std::atomic_ulong> fDataPerDigi;
-  
-  
+
 };
 
 #endif

--- a/DDC10.cc
+++ b/DDC10.cc
@@ -1,8 +1,9 @@
-#include <iostream>
 #include "DDC10.hh"
+#include <iostream>
 #include <tcl8.6/expect.h>
 #include <sys/wait.h>
 #include <math.h>
+#include <string>
 
 
 // Note: Need to make sure that you have tcl8.6 and expect libraries for communication with the DDC10 device
@@ -25,7 +26,7 @@ int DDC10::Initialize(HEVOptions d_opts)
 	exp_loguser = 0;
         
 	// Connect to DDC10 via ssh
-        string temp = "ssh root@";
+        std::string temp = "ssh root@";
         temp += d_opts.address; 
 
         // exp_open spawn ssh and returns a stream.

--- a/DDC10.hh
+++ b/DDC10.hh
@@ -3,7 +3,6 @@
 
 #include "Options.hh"
 
-
 using namespace std;
 
 class DDC10{

--- a/MongoLog.cc
+++ b/MongoLog.cc
@@ -1,6 +1,6 @@
 #include "MongoLog.hh"
-#include <sstream>
 #include <experimental/filesystem>
+#include <iostream>
 
 MongoLog::MongoLog(bool LocalFileLogging, int DeleteAfterDays){
   fLogLevel = 0;

--- a/MongoLog.hh
+++ b/MongoLog.hh
@@ -1,15 +1,16 @@
 #ifndef _MONGOLOG_HH_
 #define _MONGOLOG_HH_
 
-#include <iostream>
 #include <unistd.h>
-#include <limits.h>
 #include <sstream>
 #include <fstream>
 #include <iomanip>
 #include <cstdarg>
 #include <cstring>
 #include <mutex>
+#include <string>
+#include <map>
+#include <vector>
 
 #include <mongocxx/client.hpp>
 #include <mongocxx/uri.hpp>

--- a/Options.cc
+++ b/Options.cc
@@ -1,4 +1,6 @@
 #include "Options.hh"
+#include "DAXHelpers.hh"
+#include "MongoLog.hh"
 
 Options::Options(MongoLog *log, std::string options_name, mongocxx::collection opts_collection,
 		 std::string override_opts){
@@ -9,8 +11,10 @@ Options::Options(MongoLog *log, std::string options_name, mongocxx::collection o
 }
 
 Options::~Options(){
-  if(bson_value != NULL)
+  if(bson_value != NULL) {
     delete bson_value;
+    bson_value = NULL;
+  }
 }
 
 std::string Options::ExportToString(){

--- a/Options.cc
+++ b/Options.cc
@@ -32,8 +32,10 @@ int Options::Load(std::string name, mongocxx::collection opts_collection,
     fLog->Entry(MongoLog::Warning, "Failed to find your options file '%s' in DB", name);
     return -1;
   }
-  if(bson_value != NULL)
+  if(bson_value != NULL) {
     delete bson_value;
+    bson_value = NULL;
+  }
   bson_value = new bsoncxx::document::value((*trydoc).view());
   bson_options = bson_value->view();
   

--- a/Options.hh
+++ b/Options.hh
@@ -14,8 +14,7 @@
 #include <bsoncxx/document/value.hpp>
 #include <bsoncxx/builder/stream/document.hpp>
 #include <bsoncxx/exception/exception.hpp>
-#include "DAXHelpers.hh"
-#include "MongoLog.hh"
+#include <mongocxx/collection.hpp>
 
 struct BoardType{
   int link;
@@ -63,6 +62,8 @@ struct HEVOptions{
 
 };
 
+class MongoLog;
+
 class Options{
 
 public:
@@ -87,7 +88,6 @@ public:
   int GetNestedInt(std::string path, int default_value);
 private:
   std::string defaultPath = "defaults/daxOptions.json";
-  DAXHelpers *fHelper;
   bsoncxx::document::view bson_options;
   bsoncxx::document::value *bson_value;
   MongoLog *fLog;

--- a/StraxInserter.cc
+++ b/StraxInserter.cc
@@ -1,6 +1,12 @@
-#include <lz4frame.h>
 #include "StraxInserter.hh"
+#include <lz4frame.h>
 #include "DAQController.hh"
+#include "MongoLog.hh"
+#include "Options.hh"
+#include <blosc.h>
+#include <thread>
+#include <cstring>
+#include <cstdarg>
 
 StraxInserter::StraxInserter(){
   fOptions = NULL;
@@ -38,11 +44,11 @@ int StraxInserter::Initialize(Options *options, MongoLog *log, DAQController *da
   // To start we do not know which FW version we're dealing with (for data parsing)
   fFirmwareVersion = fOptions->GetInt("firmware_version", -1);
   if(fFirmwareVersion == -1){
-	cout<<"Firmware version unspecified in options"<<endl;
+	std::cout<<"Firmware version unspecified in options"<<std::endl;
 	return -1;
   }
   if((fFirmwareVersion != 0) && (fFirmwareVersion != 1)){
-	cout<<"Firmware version unidentified, accepted versions are {0, 1}"<<endl;
+	std::cout<<"Firmware version unidentified, accepted versions are {0, 1}"<<std::endl;
 	return -1;
   }
 
@@ -84,8 +90,8 @@ void StraxInserter::ParseDocuments(data_packet dp){
   unsigned int max_channels = 16; // hardcoded to accomodate V1730
   
   // Unpack the things from the data packet
-  vector<u_int32_t> clock_counters(max_channels, dp.clock_counter);
-  vector<u_int32_t> last_times_seen(max_channels, 0xFFFFFFFF);
+  std::vector<u_int32_t> clock_counters(max_channels, dp.clock_counter);
+  std::vector<u_int32_t> last_times_seen(max_channels, 0xFFFFFFFF);
   
   u_int32_t size = dp.size;
   u_int32_t *buff = dp.buff;
@@ -239,7 +245,7 @@ void StraxInserter::ParseDocuments(data_packet dp){
 	  
 	  // Copy the raw buffer	  
 	  if(samples_this_channel>fFragmentLength/2){
-	    cout<<samples_this_channel<<"!"<<std::endl;
+	    std::cout<<samples_this_channel<<"!"<<std::endl;
 	    exit(-1);
 	  }
 

--- a/StraxInserter.hh
+++ b/StraxInserter.hh
@@ -2,23 +2,18 @@
 #define _STRAXINSERTER_HH_
 
 #include <cstdlib>
-#include <cstdarg>
-#include <cstring>
-#include <assert.h>
-#include <blosc.h>
-#include <thread>
-//#include "MongoInserter.hh"
+#include <cstdint>
+#include <string>
 
 //for debugging
 //#include <sys/types.h>
 #include <map>
 #include <mutex>
-#include <blosc.h>
 #include <experimental/filesystem>
-#include "Options.hh"
-#include "MongoLog.hh"
 
 class DAQController;
+class Options;
+class MongoLog;
 
 struct data_packet{
   u_int32_t *buff;

--- a/V1724.cc
+++ b/V1724.cc
@@ -4,6 +4,12 @@
 #include <algorithm>
 #include <bitset>
 #include <cmath>
+#include <unistd.h>
+#include <cstring>
+#include <iostream>
+#include "MongoLog.hh"
+#include "Options.hh"
+#include <CAENVMElib.h>
 
 
 V1724::V1724(MongoLog  *log, Options *options){
@@ -12,7 +18,6 @@ V1724::V1724(MongoLog  *log, Options *options){
   fBaseAddress=0;
   fLog = log;
 
-  fNChannels = 8;
   fAqCtrlRegister = 0x8100;
   fAqStatusRegister = 0x8104;
   fSwTrigRegister = 0x8108;
@@ -31,9 +36,9 @@ V1724::V1724(MongoLog  *log, Options *options){
     // i.e. the channel size is at index '0'
     {"channel_time_msb_idx", -1},
     {"channel_time_msb_mask", -1},
-    
+
   };
-  
+
 }
 V1724::~V1724(){
   End();
@@ -63,11 +68,10 @@ u_int32_t V1724::GetAcquisitionStatus(){
 
 
 int V1724::Init(int link, int crate, int bid, unsigned int address){
-	  
   int a = CAENVME_Init(cvV2718, link, crate, &fBoardHandle);
   if(a != cvSuccess){
-    cout<<"Failed to init board, error code: "<<a<<", handle: "<<fBoardHandle<<
-      " at link "<<link<<" and bdnum "<<crate<<endl;
+    std::cout<<"Failed to init board, error code: "<<a<<", handle: "<<fBoardHandle<<
+      " at link "<<link<<" and bdnum "<<crate<<std::endl;
     fBoardHandle = -1;
     return -1;
   }
@@ -78,7 +82,7 @@ int V1724::Init(int link, int crate, int bid, unsigned int address){
   fCrate = crate;
   fBID = bid;
   fBaseAddress=address;
-  cout<<"Successfully initialized board at "<<fBoardHandle<<endl;
+  std::cout<<"Successfully initialized board at "<<fBoardHandle<<std::endl;
   clock_counter = 0;
   last_time = 0;
   seen_over_15 = false;
@@ -204,8 +208,8 @@ int64_t V1724::ReadMBLT(unsigned int *&buffer){
   // the other, V1724G, has 512 MS/channel = 1MB/channel
   //unsigned int BLT_SIZE=8388608; //8*8388608; // 8MB buffer size
   unsigned int BLT_SIZE=524288;
-  vector<u_int32_t*> transferred_buffers;
-  vector<u_int32_t> transferred_bytes;
+  std::vector<u_int32_t*> transferred_buffers;
+  std::vector<u_int32_t> transferred_bytes;
 
   int count = 0;
   do{
@@ -269,7 +273,7 @@ int64_t V1724::ReadMBLT(unsigned int *&buffer){
   
 }
 
-int V1724::ConfigureBaselines(vector <u_int16_t> &end_values,
+int V1724::ConfigureBaselines(std::vector <u_int16_t> &end_values,
 			      int nominal_value, int ntries){
   // The point of this function is to set the voltage offset per channel such
   // that the baseline is at exactly 16000 (or whatever value is set in the
@@ -290,7 +294,7 @@ int V1724::ConfigureBaselines(vector <u_int16_t> &end_values,
   u_int32_t words_in_event(0), channel_mask(0), words_per_channel(0), idx(0);
   int channels_in_event(0);
 
-  vector<int> hist(nbins);
+  std::vector<int> hist(nbins);
   // some iterators to handle looping through the histogram
   auto beg_it = hist.begin();
   auto max_it = beg_it;
@@ -300,26 +304,26 @@ int V1724::ConfigureBaselines(vector <u_int16_t> &end_values,
   // +1 for exclusive endpoint
   auto max_end = max_it;
 
-  array<int, 3> DAC_calibration = {60000, 30000, 6000};
-  array<double, 16> calibration_slope; // 16 channel support
-  array<double, 16> calibration_intercept;
-  array<u_int16_t, 16> min_dac;
+  std::array<int, 3> DAC_calibration = {60000, 30000, 6000};
+  std::array<double, 16> calibration_slope; // 16 channel support
+  std::array<double, 16> calibration_intercept;
+  std::array<u_int16_t, 16> min_dac;
   u_int16_t max_dac(0xffff);
   
   // if the calibration points change, these numbers also change
   // B = sum(x^2), C = sum(1), F = sum(x)
   double B(4536000000.), C(3.), D(0), E(0), F(96000.);
 
-  array<vector<double>, 16> bl_per_channel;
+  std::array<std::vector<double>, 16> bl_per_channel;
 
-  vector<u_int16_t> dac_values(fNChannels);
+  std::vector<u_int16_t> dac_values(fNChannels);
   std::stringstream msg;
   msg << "Found starting values for digi " << fBID << " BLs:" << std::hex;
   for (auto& v : dac_values) msg << " 0x" << v << ",";
   fLog->Entry(MongoLog::Local, msg.str());
 
-  vector<int> channel_finished(fNChannels, 0);
-  vector<bool> update_dac(fNChannels, true);
+  std::vector<int> channel_finished(fNChannels, 0);
+  std::vector<bool> update_dac(fNChannels, true);
 
   u_int32_t* buffer;
   int bytes_read;
@@ -496,7 +500,7 @@ int V1724::ConfigureBaselines(vector <u_int16_t> &end_values,
 }
 
 
-int V1724::LoadDAC(vector<u_int16_t>dac_values, vector<bool> &update_dac){
+int V1724::LoadDAC(std::vector<u_int16_t> &dac_values, std::vector<bool> &update_dac){
   // Loads DAC values into registers
   for(unsigned int x=0; x<dac_values.size(); x++){
     if(x>fNChannels || update_dac[x]==false) // oops
@@ -543,8 +547,8 @@ bool V1724::MonitorRegister(u_int32_t reg, u_int32_t mask, int ntries, int sleep
     counter++;
     usleep(sleep);
   }
-  std::cout<<"MonitorRegister failed for "<<hex<<reg<<" with mask "<<
-    mask<<" and register value "<<rval<<"... couldn't get "<<val<<dec<<
+  std::cout<<"MonitorRegister failed for "<<std::hex<<reg<<" with mask "<<
+    mask<<" and register value "<<rval<<"... couldn't get "<<val<<std::dec<<
     std::endl;
   return false;
 }

--- a/V1724.hh
+++ b/V1724.hh
@@ -1,18 +1,12 @@
 #ifndef _V1724_HH_
 #define _V1724_HH_
 
-#include <unistd.h>
-#include <cstring>
-
-#include <stdint.h>
-#include <CAENVMElib.h>
+#include <cstdint>
 #include <vector>
+#include <map>
 
-#include <iostream>
-#include "MongoLog.hh"
-#include "Options.hh"
-
-using namespace std;
+class MongoLog;
+class Options;
 
 class V1724{
 
@@ -24,7 +18,7 @@ class V1724{
   int64_t ReadMBLT(u_int32_t *&buffer);
   int WriteRegister(unsigned int reg, unsigned int value);
   unsigned int ReadRegister(unsigned int reg);
-  int ConfigureBaselines(vector <u_int16_t> &end_values,
+  int ConfigureBaselines(std::vector <u_int16_t> &end_values,
 			 int nominal_value=16000,
 			 int ntries=100);
   int GetClockCounter(u_int32_t timestamp);
@@ -34,7 +28,7 @@ class V1724{
     return fBID;
   };
 
-  int LoadDAC(vector<u_int16_t>dac_values, vector<bool> &update_dac);
+  int LoadDAC(std::vector<u_int16_t> &dac_values, std::vector<bool> &update_dac);
 
   // Acquisition Control
   int SINStart();
@@ -45,7 +39,7 @@ class V1724{
   bool EnsureStopped(int ntries, int sleep);
   u_int32_t GetAcquisitionStatus();
   u_int32_t GetHeaderTime(u_int32_t *buff, u_int32_t size);
-  
+
   int fNsPerSample;
   std::map<std::string, int> DataFormatDefinition;
 

--- a/V1724_MV.cc
+++ b/V1724_MV.cc
@@ -1,4 +1,6 @@
 #include "V1724_MV.hh"
+#include "MongoLog.hh"
+#include "Options.hh"
 
 V1724_MV::V1724_MV(MongoLog *log, Options *options)
   :V1724(log, options){

--- a/V2718.hh
+++ b/V2718.hh
@@ -1,20 +1,9 @@
 #ifndef _V2718_HH_
 #define _V2718_HH_
 
-
-#include <CAENVMElib.h>
-#include "MongoLog.hh"
 #include "Options.hh"
 
-//#include <unistd.h>
-//#include <cstring>
-//#include <stdint.h>
-//#include <vector>
-//#include <iostream>
-
-using namespace std;
-
-
+class MongoLog;
 
 class V2718{
  
@@ -40,6 +29,3 @@ private:
 };
 
 #endif
-
-
-

--- a/ccontrol.cc
+++ b/ccontrol.cc
@@ -1,4 +1,10 @@
 #include "CControl_Handler.hh"
+#include "Options.hh"
+#include "MongoLog.hh"
+#include <string>
+#include <iostream>
+#include <limits.h>
+#include <unistd.h>
 
 int main(int argc, char** argv){
   

--- a/ccontrol.cc
+++ b/ccontrol.cc
@@ -114,8 +114,10 @@ int main(int argc, char** argv){
        }	  
               
        //Here are our options
-       if(options != NULL)
+       if(options != NULL) {
 	 delete options;
+	 options = NULL;
+       }
        options = new Options(logger, mode, options_collection, override_json);
 	 
        // Initialise the V2178, V1495 and DDC10...etc.      

--- a/main.cc
+++ b/main.cc
@@ -209,8 +209,10 @@ int main(int argc, char** argv){
 	    bool initialized = false;
 	    
 	    // Mongocxx types confusing so passing json strings around
-	    if(fOptions != NULL)
+	    if(fOptions != NULL) {
 	      delete fOptions;
+	      fOptions = NULL;
+	    }
 	    fOptions = new Options(logger, (doc)["mode"].get_utf8().value.to_string(),
 				   options_collection, override_json);
 	    std::vector<int> links;

--- a/main.cc
+++ b/main.cc
@@ -2,8 +2,12 @@
 #include <string>
 #include <iomanip>
 #include <csignal>
-#include "V1724.hh"
 #include "DAQController.hh"
+#include <thread>
+#include <unistd.h>
+#include "MongoLog.hh"
+#include "Options.hh"
+#include <limits.h>
 
 bool b_run = true;
 
@@ -31,7 +35,7 @@ int main(int argc, char** argv){
     std::cout<<"...exiting"<<std::endl;
     exit(0);
   }
-  string dbname = "xenonnt";
+  std::string dbname = "xenonnt";
   if(argc >= 4)
     dbname = argv[3];
 
@@ -40,13 +44,13 @@ int main(int argc, char** argv){
   gethostname(chostname, HOST_NAME_MAX);
   std::string hostname=chostname;
   hostname+= "_reader_";
-  string sid = argv[1];
+  std::string sid = argv[1];
   hostname += sid;
   std::cout<<"Reader starting with ID: "<<hostname<<std::endl;
   
   // MongoDB Connectivity for control database. Bonus for later:
   // exception wrap the URI parsing and client connection steps
-  string suri = argv[2];  
+  std::string suri = argv[2];  
   mongocxx::uri uri(suri.c_str());
   mongocxx::client client(uri);
   mongocxx::database db = client[dbname];
@@ -113,8 +117,8 @@ int main(int argc, char** argv){
 	std::cout<<"Updated doc"<<std::endl;
 	
 	// Get the command out of the doc
-	string command = "";
-	string user = "";
+	std::string command = "";
+	std::string user = "";
 	try{
 	  command = (doc)["command"].get_utf8().value.to_string();
 	  user = (doc)["user"].get_utf8().value.to_string();
@@ -227,7 +231,7 @@ int main(int argc, char** argv){
 			    "Cannot start DAQ while readout thread from previous run active. Please perform a reset");
 	    }
 	    else if(!initialized){
-	      cout<<"Skipping readout configuration since init failed"<<std::endl;
+	      std::cout<<"Skipping readout configuration since init failed"<<std::endl;
 	    }
 	    else{
 	      controller->CloseProcessingThreads();


### PR DESCRIPTION
Many of the includes in the header files can be moved into the source files, and a number used in old versions removed entirely. This helps to keep object file size and compilation times down, and boosts readability. There was also inconsistent use of the explicit `std::` namespace, which was corrected (a `using namespace std;` had crept into a header file).