### PR TITLE
Framework for per-board thresholds

### DIFF
--- a/DAQController.cc
+++ b/DAQController.cc
@@ -411,10 +411,10 @@ void DAQController::InitLink(std::vector<V1724*>& digis,
 
     // Multiple options here
     int bid = digi->bid(), success(0);
-    fMapMutex.lock();
-    auto board_dac_cal = cal_values.count(bid) ? cal_values[bid] : cal_values[-1];
-    fMapMutex.unlock();
     if(BL_MODE == "cached") {
+      fMapMutex.lock();
+      auto board_dac_cal = cal_values.count(bid) ? cal_values[bid] : cal_values[-1];
+      fMapMutex.unlock();
       dac_values[bid] = std::vector<u_int16_t>(digi->GetNumChannels());
       fLog->Entry(MongoLog::Local, "Board %i using cached baselines", bid);
       for (unsigned ch = 0; ch < digi->GetNumChannels(); ch++)
@@ -456,6 +456,8 @@ void DAQController::InitLink(std::vector<V1724*>& digis,
 
     // Load the baselines you just configured
     success += digi->LoadDAC(dac_values[bid]);
+    // Load all the other fancy stuff
+    success += digi->SetThresholds(fOptions->GetThresholds(bid));
 
     fLog->Entry(MongoLog::Local,
 	"DAC finished for %i. Assuming not directly followed by an error, that's a wrap.",
@@ -465,7 +467,7 @@ void DAQController::InitLink(std::vector<V1724*>& digis,
       fLog->Entry(MongoLog::Warning, "Failed to configure digitizers.");
       ret = -1;
       return;
-      }
+    }
   } // loop over digis per link
 
   ret = 0;

--- a/DAQController.cc
+++ b/DAQController.cc
@@ -477,9 +477,9 @@ int DAQController::FitBaselines(std::vector<V1724*> &digis,
     std::map<int, std::map<std::string, std::vector<double>>> &cal_values) {
   using std::vector;
   using namespace std::chrono_literals;
-  int max_iter(1);
+  int max_iter(2);
   unsigned max_steps(20), digis_this_link(digis.size()), ch_per_digi(digis[0]->GetNumChannels());
-  int adjustment_threshold(10), convergence_threshold(3), min_adjustment(8);
+  int adjustment_threshold(10), convergence_threshold(3), min_adjustment(0xA);
   int rebin_factor(1); // log base 2
   int nbins(1 << (14-rebin_factor)), bins_around_max(3);
   int triggers_per_step = 3, steps_repeated(0), max_repeated_steps(10);

--- a/Options.cc
+++ b/Options.cc
@@ -209,10 +209,21 @@ std::vector<RegisterType> Options::GetRegisters(int board){
     ret.push_back(rt);
   }
   return ret;
-
-  
 }
 
+std::vector<u_int16_t> Options::GetThresholds(int board) {
+  std::vector<u_int16_t> thresholds;
+  u_int16_t default_threshold = 0xA;
+  try{
+    for (auto& val : bson_options["thresholds"][std::to_string(board)])
+      thresholds.push_back(val.get_int32().value);
+    return thresholds;
+  }
+  catch(std::exception& e){
+    fLog->Entry(MongoLog::Local, "Using default thresholds for %i", board);
+    return std::vector<u_int16_t>(16, default_threshold);
+  }
+}
 
 int Options::GetCrateOpt(CrateOptions &ret){
   // I think we can just hack the above getters to allow dot notation
@@ -228,7 +239,7 @@ int Options::GetCrateOpt(CrateOptions &ret){
     return -1;
   }
   return 0;
-}	
+}
 
 int Options::GetChannel(int bid, int cid){
   std::string boardstring = std::to_string(bid);

--- a/Options.cc
+++ b/Options.cc
@@ -272,8 +272,8 @@ int Options::GetDAC(std::map<int, std::map<std::string, std::vector<double>>>& b
                     std::vector<int>& bids) {
   board_dacs.clear();
   std::map<std::string, std::vector<double>> defaults {
-                {"slope", std::vector<double>(16, -0.26)},
-                {"yint", std::vector<double>(16, 17200)}};
+                {"slope", std::vector<double>(16, -0.2695)},
+                {"yint", std::vector<double>(16, 17169)}};
   // let's provide a default
   board_dacs[-1] = defaults;
   std::map<std::string, std::vector<double>> this_board_dac{

--- a/Options.cc
+++ b/Options.cc
@@ -215,7 +215,7 @@ std::vector<u_int16_t> Options::GetThresholds(int board) {
   std::vector<u_int16_t> thresholds;
   u_int16_t default_threshold = 0xA;
   try{
-    for (auto& val : bson_options["thresholds"][std::to_string(board)])
+    for (auto& val : bson_options["thresholds"][std::to_string(board)].get_array().value)
       thresholds.push_back(val.get_int32().value);
     return thresholds;
   }

--- a/Options.hh
+++ b/Options.hh
@@ -87,6 +87,7 @@ public:
   int GetHEVOpt(HEVOptions &ret);
   int GetChannel(int bid, int cid);
   int GetNestedInt(std::string path, int default_value);
+  std::vector<u_int16_t> GetThresholds(int board);
 
   void UpdateDAC(std::map<int, std::map<std::string, std::vector<double>>>&);
 private:

--- a/StraxInserter.cc
+++ b/StraxInserter.cc
@@ -116,7 +116,7 @@ void StraxInserter::ParseDocuments(data_packet dp){
       if(board_fail != 0){
 	fBoardFailCount+=1;
 	std::cout<<"Oh no your board failed"<<std::endl; //do something reasonable
-        fLog->Entry(MongoLog::Local, "Board %i failed? %x", buff[idx+1]>>27, buff[idx]);
+        fLog->Entry(MongoLog::Local, "Board %i failed? %x", buff[idx+1]>>27, buff[idx+1]);
         idx += 4;
         continue;
       }

--- a/StraxInserter.cc
+++ b/StraxInserter.cc
@@ -116,6 +116,9 @@ void StraxInserter::ParseDocuments(data_packet dp){
       if(board_fail != 0){
 	fBoardFailCount+=1;
 	std::cout<<"Oh no your board failed"<<std::endl; //do something reasonable
+        fLog->Entry(MongoLog::Local, "Board %i failed? %x", buff[idx+1]>>27, buff[idx]);
+        idx += 4;
+        continue;
       }
       
       idx += 4; // skip header

--- a/V1724.cc
+++ b/V1724.cc
@@ -25,6 +25,7 @@ V1724::V1724(MongoLog  *log, Options *options){
   fChStatusRegister = 0x1088;
   fChDACRegister = 0x1098;
   fNChannels = 8;
+  fChTrigRegister = 0x1060;
   
   DataFormatDefinition = {
     {"channel_mask_msb_idx", -1},
@@ -38,8 +39,8 @@ V1724::V1724(MongoLog  *log, Options *options){
     {"channel_time_msb_mask", -1},
 
   };
-
 }
+
 V1724::~V1724(){
   End();
 }
@@ -172,16 +173,14 @@ int V1724::GetClockCounter(u_int32_t timestamp){
 int V1724::WriteRegister(unsigned int reg, unsigned int value){
   u_int32_t write=0;
   write+=value;
-  if(CAENVME_WriteCycle(fBoardHandle, fBaseAddress+reg,
-			&write,cvA32_U_DATA,cvD32) != cvSuccess){
+  int ret = 0;
+  if((ret = CAENVME_WriteCycle(fBoardHandle, fBaseAddress+reg,
+			&write,cvA32_U_DATA,cvD32)) != cvSuccess){
     fLog->Entry(MongoLog::Warning,
-		"Board %i failed to write register 0x%04x with value %08x (handle %i)",
-		fBID, reg, value, fBoardHandle);
+		"Board %i write returned %i (ret), reg 0x%04x, value 0x%08x",
+		fBID, ret, reg, value);
     return -1;
   }
-  //fLog->Entry(MongoLog::Local, "Board %i wrote register 0x%04x with value 0x%04x",
-	//      fBID, reg, value);
-  
   return 0;
 }
 
@@ -195,8 +194,6 @@ unsigned int V1724::ReadRegister(unsigned int reg){
 		fBID, ret, temp, reg);
     return 0xFFFFFFFF;
   }
-  //fLog->Entry(MongoLog::Local, "Board %i read register 0x%04x as value 0x%04x",
-  //            fBID, reg, temp);
   return temp;
 }
 
@@ -275,17 +272,7 @@ int64_t V1724::ReadMBLT(unsigned int *&buffer){
 
 int V1724::LoadDAC(std::vector<u_int16_t> &dac_values){
   // Loads DAC values into registers
-  for(unsigned int x=0; x<dac_values.size(); x++){
-    if(x>=fNChannels) // oops
-      continue;
-
-/*    if (MonitorRegister(fChStatusRegister + 0x100*x, 0x4, 1000, 1000, 0)) {
-      fLog->Entry(MongoLog::Error, "Board %i channel %i not ready for DAC input",
-          fBID, x);
-      return -1;
-    }*/
-
-    // Now write channel DAC values
+  for(unsigned int x=0; x<fNChannels; x++){
     if(WriteRegister((fChDACRegister)+(0x100*x), dac_values[x])!=0){
       fLog->Entry(MongoLog::Error, "Board %i failed writing DAC 0x%04x in channel %i",
 		  fBID, dac_values[x], x);
@@ -294,6 +281,13 @@ int V1724::LoadDAC(std::vector<u_int16_t> &dac_values){
 
   }
   return 0;
+}
+
+int V1724::SetThresholds(std::vector<u_int16_t> vals) {
+  int ret = 0;
+  for (unsigned ch = 0; ch < fNChannels; ch++) {
+    ret += WriteRegister(fChTrigRegister + 0x100*ch, vals[ch]);
+  return ret;
 }
 
 int V1724::End(){

--- a/V1724.cc
+++ b/V1724.cc
@@ -285,7 +285,7 @@ int V1724::LoadDAC(std::vector<u_int16_t> &dac_values){
 
 int V1724::SetThresholds(std::vector<u_int16_t> vals) {
   int ret = 0;
-  for (unsigned ch = 0; ch < fNChannels; ch++) {
+  for (unsigned ch = 0; ch < fNChannels; ch++)
     ret += WriteRegister(fChTrigRegister + 0x100*ch, vals[ch]);
   return ret;
 }

--- a/V1724.hh
+++ b/V1724.hh
@@ -28,6 +28,7 @@ class V1724{
   int LoadDAC(std::vector<u_int16_t> &dac_values);
   void ClampDACValues(std::vector<u_int16_t>&, std::map<std::string, std::vector<double>>&);
   unsigned GetNumChannels() {return fNChannels;}
+  int SetThresholds(std::vector<u_int16_t> vals);
 
   // Acquisition Control
   int SINStart();
@@ -40,7 +41,6 @@ class V1724{
   u_int32_t GetAcquisitionStatus();
   u_int32_t GetHeaderTime(u_int32_t *buff, u_int32_t size);
 
-  int fNsPerSample;
   std::map<std::string, int> DataFormatDefinition;
 
 protected:
@@ -51,6 +51,7 @@ protected:
   unsigned int fResetRegister;
   unsigned int fChStatusRegister;
   unsigned int fChDACRegister;
+  unsigned int fChTrigRegister;
   unsigned int fNChannels;
 
 private:

--- a/dispatcher/DAQController.py
+++ b/dispatcher/DAQController.py
@@ -393,7 +393,7 @@ class DAQController():
         '''
         # If no stop after configured, return
         try:
-            assert(type(self.goal_state[detector]['stop_after']) == int)
+            _ = int(self.goal_state[detector]['stop_after'])
         except:
             return
         

--- a/dispatcher/MongoConnect.py
+++ b/dispatcher/MongoConnect.py
@@ -302,7 +302,7 @@ class MongoConnect():
             return [], []
         cc = []
         hostlist = []
-        self.log.debug([(b['type'], b['host']) for b in doc['boards']])
+        #self.log.debug([(b['type'], b['host']) for b in doc['boards']])
         for b in doc['boards']:
             if 'V17' in b['type'] and b['host'] not in hostlist:
                 hostlist.append(b['host'])


### PR DESCRIPTION
Rather than the hard-to-maintain solution of adding hundreds or thousands of per-board register calls to set individual channel thresholds, we'll have a separate field in the config for per-channel/per-board thresholds. A routine in the V1724 class will write these to the digitizers, and we'll populate the config field from the database.