### PR TITLE
Incorporating the Muon Veto into REDAX

### DIFF
--- a/CControl_Handler.cc
+++ b/CControl_Handler.cc
@@ -83,8 +83,8 @@ int CControl_Handler::DeviceArm(int run, Options *opts){
   }
 
  
-  // Getting options for the V1495 board for the Muon Veto
-  // Init V1495_MV only when included config - Muon Veto only
+  // Getting options for the Muon Veto V1495 board
+  // Init V1495_MV only when included in config - Muon Veto only
   std::vector<BoardType> mv = fOptions->GetBoards("V1495", fProcname);
   BoardType mv_def = mv[0];
   fBID = mv_def.board;
@@ -200,7 +200,7 @@ bsoncxx::document::value CControl_Handler::GetStatusDoc(std::string hostname){
              << "delay" << fDDC10->GetHEVOptions().delay
              << bsoncxx::builder::stream::close_document;
   }
-  // Setrings for the XENONnT Muon Veto V1495 board 
+  // Write the settings for the Muon Veto V1495 board into status doc 
   if(fV1495 != NULL){
      in_array << bsoncxx::builder::stream::open_document
 	      << "type" << "V1495"

--- a/CControl_Handler.hh
+++ b/CControl_Handler.hh
@@ -24,11 +24,13 @@ public:
 private:
 
   V2718 *fV2718;
-  V1495 *fV1495;
   DDC10 *fDDC10;
+  V1495 *fV1495;
 
   int fStatus;
   int fCurrentRun;
+  int fBID;
+  int fBoardHandle;
   std::string fProcname;
   Options *fOptions;
   MongoLog *fLog;

--- a/Makefile
+++ b/Makefile
@@ -7,13 +7,13 @@ LDFLAGS = -lCAENVME -lstdc++fs -llz4 -lblosc $(shell pkg-config --libs libmongoc
 LDFLAGS_CC = ${LDFLAGS} -lexpect -ltcl8.6
 
 SOURCES_SLAVE = DAQController.cc main.cc Options.cc MongoLog.cc \
-    StraxInserter.cc V1724.cc V1724_MV.cc V1730.cc
+    StraxInserter.cc V1724.cc V1724_MV.cc
 OBJECTS_SLAVE = $(SOURCES_SLAVE:%.cc=%.o)
 DEPS_SLAVE = $(OBJECTS_SLAVE:%.o=%.d)
 EXEC_SLAVE = main
 
 SOURCES_CC = ccontrol.cc Options.cc V2718.cc \
-    CControl_Handler.cc DDC10.cc MongoLog.cc
+    CControl_Handler.cc DDC10.cc V1495.cc MongoLog.cc
 OBJECTS_CC = $(SOURCES_CC:%.cc=%.o)
 DEPS_CC = $(OBJECTS_CC:%.o=%.d)
 EXEC_CC = ccontrol

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ LDFLAGS = -lCAENVME -lstdc++fs -llz4 -lblosc $(shell pkg-config --libs libmongoc
 LDFLAGS_CC = ${LDFLAGS} -lexpect -ltcl8.6
 
 SOURCES_SLAVE = DAQController.cc main.cc Options.cc MongoLog.cc \
-    StraxInserter.cc V1724.cc V1724_MV.cc
+    StraxInserter.cc V1724.cc V1724_MV.cc V1730.cc
 OBJECTS_SLAVE = $(SOURCES_SLAVE:%.cc=%.o)
 DEPS_SLAVE = $(OBJECTS_SLAVE:%.o=%.d)
 EXEC_SLAVE = main

--- a/V1495.cc
+++ b/V1495.cc
@@ -1,0 +1,39 @@
+// ** XENONnT Muon Veto V1495 Board **
+// Generic class for writing registers to a CAEN V1495 borad
+// Initialisation of the V1724 Muon Veto boards was moved to a dedeicated V1724_MV class
+
+#include <numeric>
+#include <iostream>
+#include "V1495.hh"
+#include "DAXHelpers.hh"
+#include "Options.hh"
+#include "MongoLog.hh"
+
+
+V1495::V1495(MongoLog  *log, Options *options, int bid, int handle, unsigned int address){
+	fOptions = options;
+	fLog = log;
+	fBID = bid;
+	fBaseAddress = address;
+	fBoardHandle = handle;
+}
+
+V1495::~V1495(){}
+
+// Kept a separate write registers function for the V1495 here, but in principle can be derived from the V1724 class
+int V1495::WriteReg(unsigned int reg, unsigned int value){
+	u_int32_t write=0;
+	write+=value;
+	if(CAENVME_WriteCycle(fBoardHandle, fBaseAddress+reg,
+				&write,cvA32_U_DATA,cvD32) != cvSuccess){
+		fLog->Entry(MongoLog::Warning, "V1495: %i failed to write register 0x%04x with value %08x (handle %i)", 
+				fBID, reg, value, fBoardHandle);
+		return -1;
+	}
+	fLog->Entry(MongoLog::Message, "V1495: %i written register 0x%04x with value %08x (handle %i)",
+			fBID, reg, value, fBoardHandle);
+	return 0;
+}
+
+
+

--- a/V1495.hh
+++ b/V1495.hh
@@ -1,0 +1,38 @@
+#ifndef _V1495_HH_
+#define _V1495_HH_
+
+#include <CAENVMElib.h>
+#include "MongoLog.hh"
+#include "Options.hh"
+#include "V1724.hh"
+
+//Register address definitions taken from XENON1T m_veto class in kodiaq
+//https://github.com/coderdj/kodiaq and XENON1T DAQ m_veto config files
+
+/*
+#define V1495_ModuleReset               0x800A
+#define V1495_MaskInA                   0x1020
+#define V1495_MaskInB                   0x1024
+#define V1495_MaskInD                   0x1028
+#define V1495_MajorityThreshold         0x1014
+#define V1495_CoincidenceWidth          0x1010
+#define V1495_CTRL			0x1018
+*/
+
+using namespace std;
+
+class V1495{
+
+public:
+      V1495(MongoLog *log, Options *options, int bid, int handle, unsigned int address);
+      virtual ~V1495();	
+      int WriteReg(unsigned int reg, unsigned int value);
+
+private:
+      int fBoardHandle, fBID;
+      unsigned int fBaseAddress;
+      Options *fOptions;
+      MongoLog *fLog;
+
+};
+#endif

--- a/V1724_MV.cc
+++ b/V1724_MV.cc
@@ -4,7 +4,9 @@
 
 V1724_MV::V1724_MV(MongoLog *log, Options *options)
   :V1724(log, options){
-  DataFormatDefinition["channel_header_words"] = 0;
+	  DataFormatDefinition["channel_header_words"] = 0;
+	  // MV boards seem to have reg 0x1n80 for channel n threshold
+	  fChTrigRegister = 0x1080;
 }
 
 V1724_MV::~V1724_MV(){}

--- a/V1724_MV.hh
+++ b/V1724_MV.hh
@@ -10,7 +10,7 @@ public:
   virtual ~V1724_MV();
 
 private:
-
+  unsigned int fChTrigRegister;
 };
 
 #endif

--- a/V1724_MV.hh
+++ b/V1724_MV.hh
@@ -9,8 +9,6 @@ public:
   V1724_MV(MongoLog *log, Options *options);
   virtual ~V1724_MV();
 
-private:
-  unsigned int fChTrigRegister;
 };
 
 #endif

--- a/V2718.hh
+++ b/V2718.hh
@@ -16,14 +16,15 @@ public:
   int SendStopSignal(bool end=true); 
   
   CrateOptions GetCrateOptions(){ return fCopts;};
-  
+  int GetHandle(){return fBoardHandle;};
+
+protected:
+  int fBoardHandle;
+
 private:
   
   CrateOptions fCopts;
-  
-  int fBoardHandle;
   int fCrate, fLink;
-  
   MongoLog *fLog;
 
 };


### PR DESCRIPTION
A diagram and a general note about the Muon Veto DAQ changes for XENONnT can be found here: [Muon Veto XENONnT](https://xe1t-wiki.lngs.infn.it/doku.php?id=xenon:xenon1t:alexelykov:m_veto). These changes were already tested on reader5, would be nice if we could further test them while actually reading data from the digitisers and in a linked mode with the TPC.

Changes:
1. Makefile: Added V1495 class
2. V1495.cc/hh: class to handle register writing to the V1495 board. Maybe it can be later used to operate the TPC/n_veto V1495 boards as well 
3.  CControl_Handler.cc/hh:
    - Some extra logic to arm/init only the devices which were specified in the config
    - Control over the Muon Veto V1495  
    - Added V1495 register values output to status doc
4. V1724_MV.cc/hh: Added a different register definition for setting the Nth channel threshold