### PR TITLE
Tracks data per channel rather than per board

### DIFF
--- a/DAQController.cc
+++ b/DAQController.cc
@@ -293,7 +293,7 @@ void DAQController::ReadData(int link){
 }
 
 
-std::map<int, std::atomic_long> DAQController::GetDataPerChan(){
+std::map<int, long> DAQController::GetDataPerChan(){
   // Return a map of data transferred per channel since last update
   // Clears the private maps in the StraxInserters
   std::map <int, long> retmap;

--- a/DAQController.cc
+++ b/DAQController.cc
@@ -75,7 +75,6 @@ int DAQController::InitializeElectronics(Options *options, std::vector<int>&keys
     
     if(digi->Init(d.link, d.crate, d.board, d.vme_address)==0){
 	fDigitizers[d.link].push_back(digi);
-	fDataPerDigi[digi->bid()] = 0;
         BIDs.push_back(digi->bid());
 
 	if(std::find(keys.begin(), keys.end(), d.link) == keys.end()){
@@ -281,7 +280,6 @@ void DAQController::ReadData(int link){
 	d.header_time = fDigitizers[link][x]->GetHeaderTime(d.buff, d.size);
 	d.clock_counter = fDigitizers[link][x]->GetClockCounter(d.header_time);
 	fDatasize += d.size;
-	fDataPerDigi[d.bid] += d.size;
 	local_buffer.push_back(d);
       }
     }
@@ -295,19 +293,17 @@ void DAQController::ReadData(int link){
 }
 
 
-std::map<int, u_int64_t> DAQController::GetDataPerDigi(){
-  // Return a map of data transferred per digitizer since last update
-  // and clear the private map
-  std::map <int, u_int64_t>retmap;
-  for(auto const &kPair : fDataPerDigi){
-    retmap[kPair.first] = (u_int64_t)(fDataPerDigi[kPair.first]);
-    fDataPerDigi[kPair.first] = 0;
-  }
+std::map<int, std::atomic_long> DAQController::GetDataPerChan(){
+  // Return a map of data transferred per channel since last update
+  // Clears the private maps in the StraxInserters
+  std::map <int, long> retmap;
+  for (const auto& pt : fProcessingThreads)
+    pt.inserter->GetDataPerChan(retmap);
   return retmap;
 }
 
 std::map<std::string, int> DAQController::GetDataFormat(){
-  for( auto const& link : fDigitizers )    
+  for( auto const& link : fDigitizers )
     for(auto digi : link.second)
       return digi->DataFormatDefinition;
   return std::map<std::string, int>();

--- a/DAQController.hh
+++ b/DAQController.hh
@@ -51,8 +51,8 @@ public:
   void ReadThreadWrapper(void* data, int link);
   void ProcessingThreadWrapper(void* data);
 
-  u_int64_t GetDataSize(){ u_int64_t ds = fDatasize; fDatasize=0; return ds;};
-  std::map<int, u_int64_t> GetDataPerDigi();
+  u_int64_t GetDataSize(){ u_int64_t ds = fDatasize; fDatasize=0; return ds;}
+  std::map<int, long> GetDataPerChan();
   bool CheckErrors();
   int OpenProcessingThreads();
   void CloseProcessingThreads();
@@ -82,7 +82,6 @@ private:
   // For reporting to frontend
   std::atomic_uint64_t fBufferLength;
   u_int64_t fDatasize;
-  std::map<int, std::atomic_ulong> fDataPerDigi;
 
 };
 

--- a/StraxInserter.cc
+++ b/StraxInserter.cc
@@ -81,7 +81,7 @@ void StraxInserter::Close(std::map<int,int>& ret){
   fActive = false;
 }
 
-void GetDataPerChan(std::map<int, long>& ret) {
+void StraxInserter::GetDataPerChan(std::map<int, long>& ret) {
   for (auto& pair : fDataPerChan) {
     ret[pair.first] += pair.second;
     pair.second = 0;

--- a/StraxInserter.cc
+++ b/StraxInserter.cc
@@ -28,7 +28,7 @@ StraxInserter::StraxInserter(){
 
 }
 
-StraxInserter::~StraxInserter(){  
+StraxInserter::~StraxInserter(){
 }
 
 int StraxInserter::Initialize(Options *options, MongoLog *log, DAQController *dataSource,
@@ -81,6 +81,13 @@ void StraxInserter::Close(std::map<int,int>& ret){
   fActive = false;
 }
 
+void GetDataPerChan(std::map<int, long>& ret) {
+  for (auto& pair : fDataPerChan) {
+    ret[pair.first] += pair.second;
+    pair.second = 0;
+  }
+  return;
+}
 
 void StraxInserter::ParseDocuments(data_packet dp){
   
@@ -208,6 +215,7 @@ void StraxInserter::ParseDocuments(data_packet dp){
 
 	  // Cast everything to char so we can put it in our buffer.
 	  int16_t cl = int16_t(fOptions->GetChannel(dp.bid, channel));
+          fDataPerChan[cl] += samples_in_channel<<1;
 
 	  // Failing to discern which channel we're getting data from seems serious enough to throw
 	  if(cl==-1)
@@ -244,7 +252,7 @@ void StraxInserter::ParseDocuments(data_packet dp){
 	  u_int8_t rl = 0;
 	  char *reductionLevel = reinterpret_cast<char*> (&rl);
 	  fragment.append(reductionLevel, 1);
-	  
+
 	  // Copy the raw buffer
 	  if(samples_this_channel>fFragmentLength/2){
 	    std::cout<<samples_this_channel<<"!"<<std::endl;

--- a/StraxInserter.cc
+++ b/StraxInserter.cc
@@ -194,10 +194,15 @@ void StraxInserter::ParseDocuments(data_packet dp){
 	// bit because we want to allow also odd numbers of samples
 	// as FragmentLength
 	u_int16_t *payload = reinterpret_cast<u_int16_t*>(buff);
-	u_int32_t samples_in_channel = (channel_words)*2;
+	u_int32_t samples_in_channel = channel_words<<1;
 	u_int32_t index_in_sample = 0;
 	u_int32_t offset = idx*2;
 	u_int16_t fragment_index = 0;
+	int16_t cl = int16_t(fOptions->GetChannel(dp.bid, channel));
+        fDataPerChan[cl] += samples_in_channel<<1;
+	// Failing to discern which channel we're getting data from seems serious enough to throw
+	if(cl==-1)
+	  throw std::runtime_error("Failed to parse channel map. I'm gonna just kms now.");
 	
 	while(index_in_sample < samples_in_channel){
 	  std::string fragment;
@@ -211,15 +216,6 @@ void StraxInserter::ParseDocuments(data_packet dp){
 					    (fragment_index*fFragmentLength/2));
 	    samples_this_channel = max_sample-index_in_sample;
 	  }
-	  
-
-	  // Cast everything to char so we can put it in our buffer.
-	  int16_t cl = int16_t(fOptions->GetChannel(dp.bid, channel));
-          fDataPerChan[cl] += samples_in_channel<<1;
-
-	  // Failing to discern which channel we're getting data from seems serious enough to throw
-	  if(cl==-1)
-	    throw std::runtime_error("Failed to parse channel map. I'm gonna just kms now.");
 
 	  char *channelLoc = reinterpret_cast<char*> (&cl);
 	  fragment.append(channelLoc, 2);

--- a/StraxInserter.hh
+++ b/StraxInserter.hh
@@ -10,6 +10,7 @@
 #include <map>
 #include <mutex>
 #include <experimental/filesystem>
+#include <atomic>
 
 class DAQController;
 class Options;
@@ -38,7 +39,8 @@ public:
   void Close(std::map<int,int>& ret);
   
   int ReadAndInsertData();
-  bool CheckError(){ return fErrorBit; };
+  bool CheckError(){ return fErrorBit; }
+  void GetDataPerChan(std::map<int, long>& ret);
   
 private:
   void ParseDocuments(data_packet dp);
@@ -67,6 +69,7 @@ private:
   int fBoardFailCount;
   std::map<std::string, int>fFmt;
   std::map<int, int> fFailCounter;
+  std::map<int, std::atomic_long> fDataPerChan;
 };
 
 #endif

--- a/main.cc
+++ b/main.cc
@@ -275,10 +275,10 @@ int main(int argc, char** argv){
 	"buffer_length" << controller->buffer_length()/1e6 <<
 	"run_mode" << controller->run_mode() <<
 	"current_run_id" << current_run_id <<
-	"boards" << bsoncxx::builder::stream::open_document <<
+	"channels" << bsoncxx::builder::stream::open_document <<
 	[&](bsoncxx::builder::stream::key_context<> doc){
-	for( auto const& kPair : controller->GetDataPerDigi() )	  
-	  doc << std::to_string(kPair.first) << kPair.second/1e6;
+	for( auto const& pair : controller->GetDataPerChan() )
+	  doc << std::to_string(pair.first) << (pair.second>>10); // KB not MB
 	} << bsoncxx::builder::stream::close_document;
 	status.insert_one(insert_doc << bsoncxx::builder::stream::finalize);
     }catch(const std::exception &e){


### PR DESCRIPTION
Implements #42 . The website doesn't explicitly need updating because the routine that used data per board was never fully implemented.