### PR TITLE
More detailed info for when boards "fail"

### DIFF
--- a/DAQController.cc
+++ b/DAQController.cc
@@ -76,11 +76,13 @@ int DAQController::InitializeElectronics(Options *options, std::vector<int>&keys
     if(digi->Init(d.link, d.crate, d.board, d.vme_address)==0){
 	fDigitizers[d.link].push_back(digi);
         BIDs.push_back(digi->bid());
+        fBoardMap[digi->bid()] = digi;
+        fCheckFails[digi->bid()] = false;
 
 	if(std::find(keys.begin(), keys.end(), d.link) == keys.end()){
 	  fLog->Entry(MongoLog::Local, "Defining a new optical link at %i", d.link);
 	  keys.push_back(d.link);
-	}    
+	}
 	fLog->Entry(MongoLog::Debug, "Initialized digitizer %i", d.board);
 	
 	int write_success = 0;
@@ -202,12 +204,13 @@ int DAQController::Stop(){
   fStatus = DAXHelpers::Idle;
   return 0;
 }
+
 void DAQController::End(){
   Stop();
   fLog->Entry(MongoLog::Local, "Closing Processing Threads");
   CloseProcessingThreads();
   fLog->Entry(MongoLog::Local, "Closing Digitizers");
-  for( auto const& link : fDigitizers ){    
+  for( auto const& link : fDigitizers ){
     for(auto digi : link.second){
       digi->End();
       delete digi;
@@ -248,24 +251,38 @@ void DAQController::ReadData(int link){
   fBufferMutex.unlock();
   
   u_int32_t lastRead = 0; // bytes read in last cycle. make sure we clear digitizers at run stop
+  u_int32_t board_status = 0;
   long int readcycler = 0;
+  int err_val = 0;
+  std::vector<data_packet> local_buffer;
   while(fReadLoop){
     
-    std::vector<data_packet> local_buffer;
-    for(unsigned int x=0; x<fDigitizers[link].size(); x++){
+    for(auto digi : fDigitizers[link]) {
 
       // Every 1k reads check board status
       if(readcycler%10000==0){
 	readcycler=0;
-	u_int32_t data = fDigitizers[link][x]->GetAcquisitionStatus();
+        board_status = digi->GetAcquisitionStatus();
         fLog->Entry(MongoLog::Local, "Board %i has status 0x%04x",
-            fDigitizers[link][x]->bid(), data);
+            digi->bid(), board_status);
+      }
+      if (fCheckFails[digi->bid()]) {
+        fCheckFails[digi->bid()] = false;
+        err_val = fBoardMap[digi->bid()]->CheckErrors();
+        if (err_val == -1) {
+
+        } else {
+          if (err_val & 0x1) fLog->Entry(MongoLog::Local, "Board %i has PLL unlock",
+                                         digi->bid());
+          if (err_val & 0x2) fLog->Entry(MongoLog::Local, "Board %i has VME bus error",
+                                         digi->bid());
+        }
       }
       data_packet d;
       d.buff=NULL;
       d.size=0;
-      d.bid = fDigitizers[link][x]->bid();
-      d.size = fDigitizers[link][x]->ReadMBLT(d.buff);
+      d.bid = digi->bid();
+      d.size = digi->ReadMBLT(d.buff);
 
       lastRead += d.size;
       
@@ -278,21 +295,20 @@ void DAQController::ReadData(int link){
 	break;
       }
       if(d.size>0){
-	d.header_time = fDigitizers[link][x]->GetHeaderTime(d.buff, d.size);
-	d.clock_counter = fDigitizers[link][x]->GetClockCounter(d.header_time);
+	d.header_time = digi->GetHeaderTime(d.buff, d.size);
+	d.clock_counter = digi->GetClockCounter(d.header_time);
 	fDatasize += d.size;
 	local_buffer.push_back(d);
       }
-    }
+    } // for digi in digitizers
     if(local_buffer.size()!=0)
       AppendData(local_buffer);
     local_buffer.clear();
     readcycler++;
     usleep(1);
-  }
+  } // while run
 
 }
-
 
 std::map<int, long> DAQController::GetDataPerChan(){
   // Return a map of data transferred per channel since last update

--- a/DAQController.cc
+++ b/DAQController.cc
@@ -269,6 +269,7 @@ void DAQController::ReadData(int link){
       if (fCheckFails[digi->bid()]) {
         fCheckFails[digi->bid()] = false;
         err_val = fBoardMap[digi->bid()]->CheckErrors();
+	fLog->Entry(MongoLog::Local, "Error %i from board %i", err_val, digi->bid());
         if (err_val == -1) {
 
         } else {

--- a/DAQController.hh
+++ b/DAQController.hh
@@ -54,6 +54,7 @@ public:
   u_int64_t GetDataSize(){ u_int64_t ds = fDatasize; fDatasize=0; return ds;}
   std::map<int, long> GetDataPerChan();
   bool CheckErrors();
+  void CheckError(int bid) {fCheckFails[bid] = true;}
   int OpenProcessingThreads();
   void CloseProcessingThreads();
   long GetStraxBufferSize();
@@ -83,6 +84,8 @@ private:
   // For reporting to frontend
   std::atomic_uint64_t fBufferLength;
   u_int64_t fDatasize;
+  std::map<int, V1724*> fBoardMap;
+  std::map<int, std::atomic_bool> fCheckFails;
 
 };
 

--- a/StraxInserter.cc
+++ b/StraxInserter.cc
@@ -131,6 +131,7 @@ void StraxInserter::ParseDocuments(data_packet dp){
       // I've never seen this happen but afraid to put it into the mongo log
       // since this call is in a loop
       if(board_fail){
+        fDataSource->CheckError(dp.bid);
 	fFailCounter[dp.bid]++;
         idx += 4;
         continue;

--- a/StraxInserter.hh
+++ b/StraxInserter.hh
@@ -43,6 +43,7 @@ public:
   bool CheckError(){ return fErrorBit; }
   long GetBufferSize();
   void GetDataPerChan(std::map<int, long>& ret);
+  void CheckError(int bid);
   
 private:
   void ParseDocuments(data_packet dp);

--- a/V1724.cc
+++ b/V1724.cc
@@ -27,7 +27,9 @@ V1724::V1724(MongoLog  *log, Options *options){
   fNChannels = 8;
   fChTrigRegister = 0x1060;
   fSNRegisterMSB = 0xF080;
-  fSNRegisterLSB = 0xF040;
+  fSNRegisterLSB = 0xF084;
+  fBoardFailStatRegister = 0x8178;
+  fReadoutStatusRegister = 0xEF04;
 
   DataFormatDefinition = {
     {"channel_mask_msb_idx", -1},
@@ -70,6 +72,17 @@ bool V1724::EnsureStopped(int ntries, int tsleep){
 }
 u_int32_t V1724::GetAcquisitionStatus(){
   return ReadRegister(fAqStatusRegister);
+}
+
+int V1724::CheckErrors(){
+  auto pll = ReadRegister(fBoardFailStatRegister);
+  auto ros = ReadRegister(fReadoutStatusRegister);
+  unsigned ERR = 0xFFFFFFFF;
+  if ((pll == ERR) || (ros == ERR)) return -1;
+  int ret = 0;
+  if (pll & (1 << 4)) ret |= 0x1;
+  if (ros & (1 << 2)) ret |= 0x2;
+  return ret;
 }
 
 

--- a/V1724.hh
+++ b/V1724.hh
@@ -38,6 +38,7 @@ class V1724{
   bool EnsureReady(int ntries, int sleep);
   bool EnsureStarted(int ntries, int sleep);
   bool EnsureStopped(int ntries, int sleep);
+  int CheckErrors();
   u_int32_t GetAcquisitionStatus();
   u_int32_t GetHeaderTime(u_int32_t *buff, u_int32_t size);
 
@@ -55,6 +56,8 @@ protected:
   unsigned int fNChannels;
   unsigned int fSNRegisterMSB;
   unsigned int fSNRegisterLSB;
+  unsigned int fBoardFailStatRegister;
+  unsigned int fReadoutStatusRegister;
 
   bool MonitorRegister(u_int32_t reg, u_int32_t mask, int ntries,
 		       int sleep, u_int32_t val=1);

--- a/main.cc
+++ b/main.cc
@@ -231,15 +231,14 @@ int main(int argc, char** argv){
 	    }
 	    else{
 	      controller->CloseProcessingThreads();
+	      // open nprocessingthreads
+	      if (controller->OpenProcessingThreads()) {
+		logger->Entry(MongoLog::Warning, "Could not open processing threads!");
+		controller->CloseProcessingThreads();
+		throw std::runtime_error("Error while arming");
+	      }
 	      for(unsigned int i=0; i<links.size(); i++){
 		std::cout<<"Starting readout thread for link "<<links[i]<<std::endl;
-		if (controller->OpenProcessingThreads()) {
-		  // open nprocessingthreads per link
-		  logger->Entry(MongoLog::Warning, "Could not open processing threads!");
-		  // fail somehow?
-		  controller->CloseProcessingThreads();
-		  throw std::runtime_error("Error while arming");
-		}
 		std:: thread *readoutThread = new std::thread
 		  (
 		   &DAQController::ReadData, controller, links[i]);


### PR DESCRIPTION
If a board reports the "board fail" bit in an event header, the responsible StraxInserter sends a message upstream to its DAQController, which then checks that board to see what's up. The board reads the Board Fail Status register (0x8178) for PLL unlocks, and the Readout Status register (0xEF04) for VME bus failures. In the event of a PLL unlock, the read to 0xEF04 resets the error.

Also included in this PR, the config value for `n_processing_threads` is now global, not per link, which addresses an issue where bootstrax was waiting for the wrong number of files (fixing #54).