### PR TITLE
Updates Strax output

### DIFF
--- a/StraxInserter.cc
+++ b/StraxInserter.cc
@@ -326,7 +326,7 @@ void StraxInserter::ParseDocuments(data_packet* dp){
 	  char *fragmentindex = reinterpret_cast<char*> (&fragment_index);
 	  fragment.append(fragmentindex, 2);
 
-          char* bl = reinterpret_cast<char*>(&baseline);
+          char* bl = reinterpret_cast<char*>(&baseline_ch);
           fragment.append(bl, 2);
 
 	  // Copy the raw buffer
@@ -334,7 +334,7 @@ void StraxInserter::ParseDocuments(data_packet* dp){
 	  fragment.append(data_loc, samples_this_channel*2);
     uint8_t zero_filler = 0;
     char *zero = reinterpret_cast<char*> (&zero_filler);
-	  while(fragment.size()<fFragmentLength+fStraxHeaderSize)
+	  while(fragment.size()<fFragmentBytes+fStraxHeaderSize)
 	    fragment.append(zero, 1); // int(0) != int("0")
 
 	  //copy(data_loc, data_loc+(samples_this_channel*2),&(fragment[31]));

--- a/StraxInserter.cc
+++ b/StraxInserter.cc
@@ -20,7 +20,7 @@ StraxInserter::StraxInserter(){
   fChunkNameLength=6;
   fChunkOverlap = 0x2FAF080;
   fFragmentLength=110*2;
-  fStraxHeaderSize=22;
+  fStraxHeaderSize=24;
   fLog = NULL;
   fErrorBit = false;
   fMissingVerified = 0;
@@ -136,17 +136,17 @@ void StraxInserter::ParseDocuments(data_packet dp){
 	// These defaults are valid for 'default' firmware where all channels same size
 	u_int32_t channel_words = (words_in_event - 4) / channels_in_event;
 	u_int32_t channel_time = event_time;
-	u_int32_t channel_timeMSB; 
-	//u_int32_t baseline_ch;     
+	u_int32_t channel_timeMSB = 0;
+	u_int16_t baseline_ch = 0;
 
 	// Presence of a channel header indicates non-default firmware (DPP-DAW) so override
 	if(fmt["channel_header_words"] > 0){
 	  channel_words = (buff[idx]&0x7FFFFF)-fmt["channel_header_words"];
 	  channel_time = buff[idx+1]&0xFFFFFFFF;
 
-	  if (fmt["channel_time_msb_idx"] == 2) { 
-	    channel_timeMSB = buff[idx+2]&0xFFFF; 
-	    //baseline_ch = (buff[idx+2]>>16)&0x3FFF;  
+	  if (fmt["channel_time_msb_idx"] == 2) {
+	    channel_timeMSB = buff[idx+2]&0xFFFF;
+	    baseline_ch = (buff[idx+2]>>16)&0x3FFF;
 	  }
 	  
 	  idx += fmt["channel_header_words"];
@@ -252,6 +252,9 @@ void StraxInserter::ParseDocuments(data_packet dp){
 
 	  char *fragmentindex = reinterpret_cast<char*> (&fragment_index);
 	  fragment.append(fragmentindex, 2);
+
+          char* bl = reinterpret_cast<char*>(&baseline);
+          fragment.append(bl, 2);
 
 	  // Copy the raw buffer
 	  if(samples_this_channel>fFragmentLength/2){

--- a/StraxInserter.hh
+++ b/StraxInserter.hh
@@ -60,7 +60,6 @@ private:
   u_int16_t fFragmentLength; // This is in BYTES
   u_int16_t fStraxHeaderSize; // in BYTES too
   u_int32_t fChunkNameLength;
-  int fChunkAlloc, fOverlapAlloc; // bytes
   std::string fOutputPath, fHostname;
   Options *fOptions;
   MongoLog *fLog;

--- a/StraxInserter.hh
+++ b/StraxInserter.hh
@@ -60,8 +60,7 @@ private:
   u_int16_t fFragmentLength; // This is in BYTES
   u_int16_t fStraxHeaderSize; // in BYTES too
   u_int32_t fChunkNameLength;
-  int fChunkAllocSize; // bytes
-  int fOverlapAllocSize; // bytes
+  int fChunkAlloc, fOverlapAlloc; // bytes
   std::string fOutputPath, fHostname;
   Options *fOptions;
   MongoLog *fLog;

--- a/StraxInserter.hh
+++ b/StraxInserter.hh
@@ -60,6 +60,8 @@ private:
   u_int16_t fFragmentLength; // This is in BYTES
   u_int16_t fStraxHeaderSize; // in BYTES too
   u_int32_t fChunkNameLength;
+  int fChunkAllocSize; // bytes
+  int fOverlapAllocSize; // bytes
   std::string fOutputPath, fHostname;
   Options *fOptions;
   MongoLog *fLog;


### PR DESCRIPTION
Based on discussion with various strax people and the needs of its users, we decided to remove the fields in the strax output that are always zero (pulse area, baseline, and data reduction). These values are added in strax.

Also part of this PR, StraxInserter now pre-allocates memory for chunks. The default sizes are 128 MiB for for main chunks and 1 MiB for overlap chunks (values per thread). The defaults can be overridden in the config, but these values give ~3 GB/chunk, which should be fine for most high-rate modes. The memory is de-alloc'd when the chunk is written to disk, but the readers have considerable memory reserves, so I don't expect it to cause issues.