### PR TITLE
Board init hotfix

### DIFF
--- a/DAQController.cc
+++ b/DAQController.cc
@@ -87,13 +87,6 @@ int DAQController::InitializeElectronics(Options *options, std::vector<int>&keys
 	}
 	fLog->Entry(MongoLog::Debug, "Initialized digitizer %i", d.board);
 	
-	if(digi->Reset()!=0){
-	  fLog->Entry(MongoLog::Error,
-		      "Digitizer %i unable to load pre-registers",
-		      digi->bid());
-	  fStatus = DAXHelpers::Idle;
-	  return -1;
-	}
     }
     else{
       delete digi;

--- a/V1724.cc
+++ b/V1724.cc
@@ -10,6 +10,7 @@
 #include "MongoLog.hh"
 #include "Options.hh"
 #include <CAENVMElib.h>
+#include <chrono>
 
 
 V1724::V1724(MongoLog  *log, Options *options){
@@ -91,7 +92,7 @@ int V1724::Init(int link, int crate, int bid, unsigned int address){
   int a = CAENVME_Init(cvV2718, link, crate, &fBoardHandle);
   if(a != cvSuccess){
     fLog->Entry(MongoLog::Warning, "Board %i failed to init, error %i handle %i link %i bdnum %i",
-            fBID, a, fBoardHandle, link, crate);
+            bid, a, fBoardHandle, link, crate);
     fBoardHandle = -1;
     return -1;
   }
@@ -112,7 +113,10 @@ int V1724::Init(int link, int crate, int bid, unsigned int address){
   if (Reset()) {
     fLog->Entry(MongoLog::Error, "Board %i unable to pre-load registers", fBID);
     return -1;
+  } else {
+    fLog->Entry(MongoLog::Local, "Board %i reset", fBID);
   }
+  std::this_thread::sleep_for(std::chrono::milliseconds(10));
   if ((word = ReadRegister(fSNRegisterLSB)) == 0xFFFFFFFF) {
     fLog->Entry(MongoLog::Error, "Board %i couldn't read its SN lsb", fBID);
     return -1;

--- a/V1724.cc
+++ b/V1724.cc
@@ -108,6 +108,11 @@ int V1724::Init(int link, int crate, int bid, unsigned int address){
   seen_under_5 = true; // starts run as true
   u_int32_t word(0);
   int my_bid(0);
+  
+  if (Reset()) {
+    fLog->Entry("Board %i unable to pre-load registers", fBID);
+    return -1
+  }
   if ((word = ReadRegister(fSNRegisterLSB)) == 0xFFFFFFFF) {
     fLog->Entry(MongoLog::Error, "Board %i couldn't read its SN lsb", fBID);
     return -1;

--- a/V1724.cc
+++ b/V1724.cc
@@ -110,8 +110,8 @@ int V1724::Init(int link, int crate, int bid, unsigned int address){
   int my_bid(0);
   
   if (Reset()) {
-    fLog->Entry("Board %i unable to pre-load registers", fBID);
-    return -1
+    fLog->Entry(MongoLog::Error, "Board %i unable to pre-load registers", fBID);
+    return -1;
   }
   if ((word = ReadRegister(fSNRegisterLSB)) == 0xFFFFFFFF) {
     fLog->Entry(MongoLog::Error, "Board %i couldn't read its SN lsb", fBID);


### PR DESCRIPTION
This PR moves the board reset commands to the board initialization, rather than in the DAQ controller, and also adds a short sleep statement between the init call and the first register access.