### PR TITLE
Support for floating-point pulser frequencies

### DIFF
--- a/Options.cc
+++ b/Options.cc
@@ -238,8 +238,12 @@ int Options::GetCrateOpt(CrateOptions &ret){
   // I think we can just hack the above getters to allow dot notation
   // for a more robust solution to access subdocuments
   try{
-    ret.s_in = bson_options["V2718"]["s_in"].get_int32().value;
-    ret.pulser_freq = bson_options["V2718"]["pulser_freq"].get_int32().value;
+    try{
+      ret.pulser_freq = float(bson_options["V2718"]["pulser_freq"].get_int32().value);
+    } catch(std::exception& e) {
+      ret.pulser_freq = bson_options["V2718"]["pulser_freq"].get_double().value;
+    }
+    ret.s_in = float(bson_options["V2718"]["s_in"].get_int32().value);
     ret.muon_veto = bson_options["V2718"]["muon_veto"].get_int32().value;
     ret.neutron_veto = bson_options["V2718"]["neutron_veto"].get_int32().value;
     ret.led_trigger = bson_options["V2718"]["led_trigger"].get_int32().value;

--- a/Options.hh
+++ b/Options.hh
@@ -34,7 +34,7 @@ struct RegisterType{
 };
 
 struct CrateOptions{
-  int pulser_freq;
+  float pulser_freq;
   int neutron_veto;
   int muon_veto;
   int led_trigger;


### PR DESCRIPTION
Allows us to set very low (<1 Hz) pulser frequencies, which might help during noise calibration.