### PR TITLE
Preallocates strax buffers

### DIFF
--- a/StraxInserter.cc
+++ b/StraxInserter.cc
@@ -228,8 +228,8 @@ void StraxInserter::ParseDocuments(data_packet dp){
 	  throw std::runtime_error("Failed to parse channel map. I'm gonna just kms now.");
 	
 	while(index_in_sample < samples_in_channel){
-	  std::string fragment;
-          fragment.reserve(fStraxHeaderSize + fFragmentLength);
+	  std::string fragment(fStraxHeaderSize + fFragmentLength*2, 0);
+          fragment.clear();
 	  
 	  // How long is this fragment?
 	  u_int32_t max_sample = index_in_sample + fFragmentLength/2;

--- a/StraxInserter.hh
+++ b/StraxInserter.hh
@@ -60,6 +60,7 @@ private:
   u_int16_t fFragmentLength; // This is in BYTES
   u_int16_t fStraxHeaderSize; // in BYTES too
   u_int32_t fChunkNameLength;
+  int fChunkAlloc, fOverlapAlloc; // bytes log2
   std::string fOutputPath, fHostname;
   Options *fOptions;
   MongoLog *fLog;


### PR DESCRIPTION
Reader2 throws a lot of errors when filling fragments, usually when allocating more space for the fragment and copying the existing data to the new location. This PR pre-allocates enough memory for each fragment, and also pre-allocates a large block of memory (~100 MB/thread) for each chunk.