### PR TITLE
Redoes the DAQController internal buffer

### DIFF
--- a/DAQController.cc
+++ b/DAQController.cc
@@ -30,8 +30,7 @@ DAQController::DAQController(MongoLog *log, std::string hostname){
   fReadLoop = false;
   fNProcessingThreads=8;
   fBufferLength = 0;
-  fRawDataBuffer = NULL;
-  fDatasize=0.;
+  fDataRate=0.;
   fHostname = hostname;
 }
 
@@ -228,6 +227,7 @@ void DAQController::ReadData(int link){
     std::for_each(fBuffer.begin(), fBuffer.end(), [](auto& dp){delete[] dp.buff;});
     fBuffer.clear();
     fBufferLength = 0;
+    fDataRate = 0;
     fBufferSize = 0;
   }
   fBufferMutex.unlock();
@@ -279,6 +279,7 @@ void DAQController::ReadData(int link){
         fBufferMutex.lock();
 	fBuffer.push_back(d);
         fBufferSize += d.size;
+        fDataRate += d.size;
         fBufferLength++;
         fBufferMutex.unlock();
       }
@@ -316,7 +317,7 @@ int DAQController::GetData(data_packet &dp){
   fBuffer.pop_front();
   fBufferLength--;
   fBufferSize -= dp.size;
-  fBufferMutex.unlock;
+  fBufferMutex.unlock();
   return dp.size;
 }
 

--- a/DAQController.cc
+++ b/DAQController.cc
@@ -313,7 +313,7 @@ void DAQController::GetDataFormat(std::map<int, std::map<std::string, int>>& ret
 int DAQController::GetData(data_packet &dp){
   if (fBufferLength == 0) return 0;
   fBufferMutex.lock();
-  if (fBufferMutex.size() == 0) {
+  if (fBuffer.size() == 0) {
     fBufferMutex.unlock();
     return 0;
   }

--- a/DAQController.cc
+++ b/DAQController.cc
@@ -313,6 +313,10 @@ void DAQController::GetDataFormat(std::map<int, std::map<std::string, int>>& ret
 int DAQController::GetData(data_packet &dp){
   if (fBufferLength == 0) return 0;
   fBufferMutex.lock();
+  if (fBufferMutex.size() == 0) {
+    fBufferMutex.unlock();
+    return 0;
+  }
   dp = *fBuffer.begin();
   fBuffer.pop_front();
   fBufferLength--;

--- a/DAQController.hh
+++ b/DAQController.hh
@@ -8,6 +8,7 @@
 #include <vector>
 #include <cstdint>
 #include <mutex>
+#include <list>
 
 class StraxInserter;
 class MongoLog;
@@ -45,7 +46,7 @@ public:
   void ReadData(int link);
   void End();
 
-  int GetData(std::vector <data_packet> *&retVec);
+  int GetData(data_packet &retVec);
     
   // Static wrapper so we can call ReadData in a std::thread
   void ReadThreadWrapper(void* data, int link);
@@ -70,11 +71,11 @@ private:
   
   std::vector <processingThread> fProcessingThreads;  
   std::map<int, std::vector <V1724*>> fDigitizers;
+  std::list<data_packet> fBuffer;
   std::mutex fBufferMutex;
   std::mutex fMapMutex;
 
   bool fReadLoop;
-  std::vector<data_packet> *fRawDataBuffer;
   int fStatus;
   int fNProcessingThreads;
   std::string fHostname;
@@ -82,11 +83,10 @@ private:
   Options *fOptions;
 
   // For reporting to frontend
-  std::atomic_uint64_t fBufferLength;
-  u_int64_t fDatasize;
+  std::atomic_uint64_t fBufferSize;
+  std::atomic_int fBufferLength;
   std::map<int, V1724*> fBoardMap;
   std::map<int, std::atomic_bool> fCheckFails;
-
 };
 
 #endif

--- a/DAQController.hh
+++ b/DAQController.hh
@@ -52,7 +52,7 @@ public:
   void ReadThreadWrapper(void* data, int link);
   void ProcessingThreadWrapper(void* data);
 
-  u_int64_t GetDataSize(){ u_int64_t ds = fDatasize; fDatasize=0; return ds;}
+  u_int64_t GetDataSize(){ u_int64_t ds = fDataRate; fDataRate=0; return ds;}
   std::map<int, long> GetDataPerChan();
   bool CheckErrors();
   void CheckError(int bid) {fCheckFails[bid] = true;}
@@ -85,6 +85,7 @@ private:
   // For reporting to frontend
   std::atomic_uint64_t fBufferSize;
   std::atomic_int fBufferLength;
+  std::atomic_int fDataRate;
   std::map<int, V1724*> fBoardMap;
   std::map<int, std::atomic_bool> fCheckFails;
 };

--- a/StraxInserter.cc
+++ b/StraxInserter.cc
@@ -86,7 +86,7 @@ void StraxInserter::GetDataPerChan(std::map<int, long>& ret) {
   return;
 }
 
-void StraxInserter::ParseDocuments(data_packet dp){
+void StraxInserter::ParseDocuments(data_packet &dp){
   
   // Take a buffer and break it up into one document per channel
   unsigned int max_channels = 16; // hardcoded to accomodate V1730
@@ -324,29 +324,20 @@ void StraxInserter::ParseDocuments(data_packet dp){
 
 
 int StraxInserter::ReadAndInsertData(){
-  
-  std::vector <data_packet> *readVector=NULL;
-  int read_length = fDataSource->GetData(readVector);  
+  data_packet dp;
   fActive = true;
   bool haddata=false;
-  while(fActive || read_length>0){
-    if(readVector != NULL){
-      haddata=true;
-      for(unsigned int i=0; i<readVector->size(); i++){
-	ParseDocuments((*readVector)[i]);
-	delete[] (*readVector)[i].buff;
-      }
-      delete readVector;
-      readVector=NULL;
-    }    
-
-    usleep(10); // 10ms sleep
-    read_length = fDataSource->GetData(readVector);
+  while(fActive){
+    if (fDataSource->GetData(dp)) {
+      haddata = true;
+      ParseDocuments(dp);
+      delete[] dp.buff;
+    } else
+      usleep(10); // 10us sleep
   }
-
   if(haddata)
     WriteOutFiles(1000000, true);
-  return 0;  
+  return 0;
 }
 
 // Can tune here as needed, these are defaults from the LZ4 examples

--- a/StraxInserter.hh
+++ b/StraxInserter.hh
@@ -46,7 +46,7 @@ public:
   void CheckError(int bid);
   
 private:
-  void ParseDocuments(data_packet dp);
+  void ParseDocuments(data_packet &dp);
   void WriteOutFiles(int smallest_index_seen, bool end=false);
 
   std::experimental::filesystem::path GetFilePath(std::string id, bool temp);
@@ -64,7 +64,7 @@ private:
   Options *fOptions;
   MongoLog *fLog;
   DAQController *fDataSource;
-  bool fActive;
+  std::atomic_bool fActive;
   bool fErrorBit;
   std::string fCompressor;
   std::map<std::string, std::string*> fFragments;

--- a/StraxInserter.hh
+++ b/StraxInserter.hh
@@ -18,6 +18,24 @@ class Options;
 class MongoLog;
 
 struct data_packet{
+  public:
+    data_packet() {buff = nullptr; size = clock_counter = header_time = bid = 0;}
+    data_packet(const data_packet& rhs) {
+      buff = rhs.buff;
+      size = rhs.size;
+      clock_counter = rhs.clock_counter;
+      header_time = rhs.header_time;
+      bid = rhs.bid;
+    }
+    ~data_packet() {buff = nullptr; size = clock_counter = header_time = bid = 0;}
+    data_packet operator=(const data_packet& rhs) {
+      buff = rhs.buff;
+      size = rhs.size;
+      clock_counter = rhs.clock_counter;
+      header_time = rhs.header_time;
+      bid = rhs.bid;
+      return *this;
+    }
   u_int32_t *buff;
   int32_t size;
   u_int32_t clock_counter;


### PR DESCRIPTION
The DAQController has an internal buffer where it holds data between when it is read by a digitizer and it is claimed for processing by a StraxInserter. This buffer was two layers of vectors, with each readout thread storing data temporarily, then pushing it into the main buffer. StraxInserter instances would then take the entire buffer for processing, and the DAQController would allocate a new buffer.

Now, the DAQController has one single buffer (implemented as a `std::list` of data packets), with digitizers pushing single data packets into the back and StraxInserters pulling single packets from the front. A mutex guards buffer access, and some atomic members keep track of buffer usage.