### PR TITLE
Better memory handling, better sanity checking

### DIFF
--- a/CControl_Handler.cc
+++ b/CControl_Handler.cc
@@ -107,7 +107,7 @@ int CControl_Handler::DeviceArm(int run, Options *opts){
   }else{
     fLog->Entry(MongoLog::Debug, "No V1495");
   }
-
+  fLog->Entry(MongoLog::Local, "Arm sequence finished");
   fStatus = DAXHelpers::Armed;
   return 0;
 
@@ -129,11 +129,13 @@ int CControl_Handler::DeviceStart(){
   }
 
   fStatus = DAXHelpers::Running;
+  fLog->Entry(MongoLog::Local, "Start sequence completed");
   return 0;
 }
 
 // Stopping the previously started devices; V2718, V1495, DDC10...
 int CControl_Handler::DeviceStop(){
+  fLog->Entry(MongoLog::Local, "Beginning stop sequence");
 
   // If V2718 here then send stop signal
   if(fV2718 != NULL){

--- a/DAQController.cc
+++ b/DAQController.cc
@@ -270,7 +270,7 @@ void DAQController::ReadData(int link){
 	break;
       }
       if(dp->size>0){
-        dp->bid = d->bid();
+        dp->bid = digi->bid();
 	dp->header_time = digi->GetHeaderTime(dp->buff, dp->size);
 	dp->clock_counter = digi->GetClockCounter(dp->header_time);
         local_buffer.push_back(dp);

--- a/DAQController.cc
+++ b/DAQController.cc
@@ -270,6 +270,7 @@ void DAQController::ReadData(int link){
 	break;
       }
       if(dp->size>0){
+        dp->bid = d->bid();
 	dp->header_time = digi->GetHeaderTime(dp->buff, dp->size);
 	dp->clock_counter = digi->GetClockCounter(dp->header_time);
         local_buffer.push_back(dp);

--- a/DAQController.cc
+++ b/DAQController.cc
@@ -577,7 +577,7 @@ int DAQController::FitBaselines(std::vector<V1724*> &digis,
 
       // readout
       for (auto d : digis)
-        bytes_read[d->bid()] = d->ReadMBLT(buffers[d->bid()]);
+        bytes_read[d->bid()] = d->ReadMBLT(buffers[d->bid()], idx); // idx unused here
 
       // decode
       if (std::any_of(bytes_read.begin(), bytes_read.end(),

--- a/DAQController.cc
+++ b/DAQController.cc
@@ -210,7 +210,7 @@ void DAQController::End(){
   if(fBuffer.size() != 0){
     fLog->Entry(MongoLog::Warning, "Deleting uncleard buffer of size %i",
 		fBuffer.size());
-    std::for_each(fBuffer.begin(), fBuffer.end(), [](auto dp){delete dp;});
+    std::for_each(fBuffer.begin(), fBuffer.end(), [](auto dp){delete[] dp.buff;});
     fBuffer.clear();
   }
 
@@ -224,7 +224,7 @@ void DAQController::ReadData(int link){
   fBufferMutex.lock();
   if(fBuffer.size() != 0){
     fLog->Entry(MongoLog::Debug, "Raw data buffer being brute force cleared.");
-    std::for_each(fBuffer.begin(), fBuffer.end(), [](auto dp){delete dp;});
+    std::for_each(fBuffer.begin(), fBuffer.end(), [](auto dp){delete[] dp.buff;});
     fBuffer.clear();
     fBufferLength = 0;
     fDataRate = 0;
@@ -236,7 +236,6 @@ void DAQController::ReadData(int link){
   int readcycler = 0;
   int err_val = 0;
   std::list<data_packet> local_buffer;
-  data_packet dp();
   int local_size;
   while(fReadLoop){
     
@@ -262,6 +261,7 @@ void DAQController::ReadData(int link){
                                          digi->bid());
         }
       }
+      data_packet dp;
       if((dp.size = digi->ReadMBLT(dp.buff, &dp.vBLT))<0){
         if (dp.buff != nullptr)
 	  delete[] dp.buff;
@@ -273,7 +273,6 @@ void DAQController::ReadData(int link){
 	dp.clock_counter = digi->GetClockCounter(dp.header_time);
         local_buffer.push_back(dp);
         local_size += dp.size;
-        dp = data_packet(); // clears
       }
     } // for digi in digitizers
     if (local_buffer.size() > 0) {

--- a/DAQController.cc
+++ b/DAQController.cc
@@ -28,7 +28,6 @@ DAQController::DAQController(MongoLog *log, std::string hostname){
   fOptions = NULL;
   fStatus = DAXHelpers::Idle;
   fReadLoop = false;
-  fRunning = false;
   fNProcessingThreads=8;
   fBufferLength = 0;
   fDataRate=0.;

--- a/DAQController.cc
+++ b/DAQController.cc
@@ -263,8 +263,10 @@ void DAQController::ReadData(int link){
       }
       data_packet dp;
       if((dp.size = digi->ReadMBLT(dp.buff, &dp.vBLT))<0){
-        if (dp.buff != nullptr)
+        if (dp.buff != nullptr) {
 	  delete[] dp.buff;
+	  dp.buff = nullptr;
+	}
 	break;
       }
       if(dp.size>0){

--- a/DAQController.cc
+++ b/DAQController.cc
@@ -317,7 +317,7 @@ void DAQController::GetDataFormat(std::map<int, std::map<std::string, int>>& ret
       retmap[digi->bid()] = digi->DataFormatDefinition;
 }
 
-int DAQController::GetData(std::list<data_packet> &ret){
+int DAQController::GetData(std::list<data_packet> &retVec){
   if (fBufferLength == 0) return 0;
   int ret = 0;
   fBufferMutex.lock();
@@ -325,7 +325,7 @@ int DAQController::GetData(std::list<data_packet> &ret){
     fBufferMutex.unlock();
     return 0;
   }
-  ret.splice(ret.end(), fBuffer);
+  retVec.splice(retVec.end(), fBuffer);
   fBufferLength = 0;
   ret = fBufferSize;
   fBufferSize = 0;

--- a/DAQController.cc
+++ b/DAQController.cc
@@ -402,15 +402,17 @@ int DAQController::OpenProcessingThreads(){
 
 void DAQController::CloseProcessingThreads(){
   std::map<int,int> board_fails;
-
   for(unsigned int i=0; i<fProcessingThreads.size(); i++){
     fProcessingThreads[i].inserter->Close(board_fails);
+    // two stage process so there's time to clear data
+  }
+  std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  for(unsigned int i=0; i<fProcessingThreads.size(); i++){
     delete fProcessingThreads[i].inserter;
-
     fProcessingThreads[i].pthread->join();
     delete fProcessingThreads[i].pthread;
-
   }
+
   fProcessingThreads.clear();
   if (std::accumulate(board_fails.begin(), board_fails.end(), 0,
 	[=](int tot, std::pair<int,int> iter) {return tot + iter.second;})) {

--- a/DAQController.cc
+++ b/DAQController.cc
@@ -604,7 +604,7 @@ int DAQController::FitBaselines(std::vector<V1724*> &digis,
         return -2;
       }
       if (std::any_of(bytes_read.begin(), bytes_read.end(), [=](auto p) {
-            return (0 <= p.second->size) && (p.second->size <= 16);})) { // header-only readouts???
+            return (0 <= p.second) && (p.second <= 16);})) { // header-only readouts???
         fLog->Entry(MongoLog::Local, "Undersized readout");
         step--;
         steps_repeated++;

--- a/DAQController.cc
+++ b/DAQController.cc
@@ -262,10 +262,8 @@ void DAQController::ReadData(int link){
         }
       }
       data_packet d;
-      d.buff=NULL;
-      d.size=0;
       d.bid = digi->bid();
-      d.size = digi->ReadMBLT(d.buff);
+      d.size = digi->ReadMBLT(d.buff, d.blt);
 
       if(d.size<0){
 	//LOG ERROR

--- a/DAQController.cc
+++ b/DAQController.cc
@@ -179,7 +179,7 @@ int DAQController::Stop(){
   do{
     one_still_running = false;
     for (auto& p : fRunning) one_still_running |= p.second;
-    if (one_still_running) std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    if (one_still_running) std::this_thread::sleep_for(std::chrono::milliseconds(100));
   }while(one_still_running && counter++ < 10);
   if (counter >= 10) fLog->Entry(MongoLog::Local, "Boards taking a while to clear");
   std::cout<<"Deactivating boards"<<std::endl;
@@ -318,6 +318,12 @@ std::map<int, int> DAQController::GetDataPerChan(){
 long DAQController::GetStraxBufferSize() {
   return std::accumulate(fProcessingThreads.begin(), fProcessingThreads.end(), 0,
       [=](long tot, processingThread pt) {return tot + pt.inserter->GetBufferSize();});
+}
+
+int DAQController::GetBufferLength() {
+  return fBufferLength.load() + std::accumulate(fProcessingThreads.begin(),
+      fProcessingThreads.end(), 0,
+      [](int tot, auto pt){return tot + pt.inserter->GetBufferLength();});
 }
 
 void DAQController::GetDataFormat(std::map<int, std::map<std::string, int>>& retmap){

--- a/DAQController.cc
+++ b/DAQController.cc
@@ -341,6 +341,7 @@ int DAQController::GetData(std::list<data_packet*> &retVec, unsigned num){
     fBufferMutex.unlock();
     return 0;
   }
+  if (num == 0) num == std::max(16, fBufferLength >> 4);
   if (num == 0) {
     retVec.splice(retVec.end(), fBuffer);
     fBufferLength = 0;

--- a/DAQController.cc
+++ b/DAQController.cc
@@ -236,7 +236,7 @@ void DAQController::ReadData(int link){
   int readcycler = 0;
   int err_val = 0;
   std::list<data_packet*> local_buffer;
-  data_packet* dp == nullptr;
+  data_packet* dp = nullptr;
   int local_size;
   while(fReadLoop){
     

--- a/DAQController.cc
+++ b/DAQController.cc
@@ -507,9 +507,9 @@ int DAQController::FitBaselines(std::vector<V1724*> &digis,
   bool done(false), redo_iter(false), fail(false), calibrate(true);
   double counts_total(0), counts_around_max(0), B,C,D,E,F, slope, yint, baseline;
   double fraction_around_max(0.8);
-  u_int32_t words_in_event, channel_mask, words_per_channel;
+  u_int32_t words_in_event, channel_mask, words_per_channel, idx;
   u_int16_t val0, val1;
-  int channels_in_event, idx;
+  int channels_in_event;
   auto beg_it = hist.begin(), max_it = hist.begin(), end_it = hist.end();
   auto max_start = max_it, max_end = max_it;
 
@@ -617,7 +617,7 @@ int DAQController::FitBaselines(std::vector<V1724*> &digis,
       for (auto d : digis) {
         bid = d->bid();
         idx = 0;
-        while ((idx * sizeof(u_int32_t) < reads[bid]->size) && (idx >= 0)) {
+        while ((idx * sizeof(u_int32_t) < reads[bid]->size)) {
           if ((reads[bid]->buff[idx]>>28) == 0xA) {
             words_in_event = reads[bid]->buff[idx]&0xFFFFFFF;
             if (words_in_event == 4) {

--- a/DAQController.hh
+++ b/DAQController.hh
@@ -76,6 +76,7 @@ private:
   std::mutex fMapMutex;
 
   std::atomic_bool fReadLoop;
+  std::map<int, std::atomic_bool> fRunning;
   int fStatus;
   int fNProcessingThreads;
   std::string fHostname;

--- a/DAQController.hh
+++ b/DAQController.hh
@@ -39,6 +39,7 @@ public:
   int buffer_length(){
     return fBufferSize;
   };
+  int GetBufferLength();
   std::string run_mode();
   
   int Start();

--- a/DAQController.hh
+++ b/DAQController.hh
@@ -46,8 +46,8 @@ public:
   void ReadData(int link);
   void End();
 
-  int GetData(std::list<data_packet*> &retVec);
-  int GetData(data_packet* &dp);
+  int GetData(std::list<data_packet> &retVec);
+  int GetData(data_packet &dp);
     
   // Static wrapper so we can call ReadData in a std::thread
   void ReadThreadWrapper(void* data, int link);
@@ -71,7 +71,7 @@ private:
   
   std::vector <processingThread> fProcessingThreads;  
   std::map<int, std::vector <V1724*>> fDigitizers;
-  std::list<data_packet*> fBuffer;
+  std::list<data_packet> fBuffer;
   std::mutex fBufferMutex;
   std::mutex fMapMutex;
 

--- a/DAQController.hh
+++ b/DAQController.hh
@@ -46,8 +46,8 @@ public:
   void ReadData(int link);
   void End();
 
-  int GetData(std::list<data_packet> &retVec);
-  int GetData(data_packet &dp);
+  int GetData(std::list<data_packet*> &retVec, unsigned num = 0);
+  int GetData(data_packet* &dp);
     
   // Static wrapper so we can call ReadData in a std::thread
   void ReadThreadWrapper(void* data, int link);
@@ -71,7 +71,7 @@ private:
   
   std::vector <processingThread> fProcessingThreads;  
   std::map<int, std::vector <V1724*>> fDigitizers;
-  std::list<data_packet> fBuffer;
+  std::list<data_packet*> fBuffer;
   std::mutex fBufferMutex;
   std::mutex fMapMutex;
 

--- a/DAQController.hh
+++ b/DAQController.hh
@@ -46,14 +46,14 @@ public:
   void ReadData(int link);
   void End();
 
-  int GetData(data_packet &retVec);
+  int GetData(std::list<data_packet> &ret);
     
   // Static wrapper so we can call ReadData in a std::thread
   void ReadThreadWrapper(void* data, int link);
   void ProcessingThreadWrapper(void* data);
 
-  u_int64_t GetDataSize(){ u_int64_t ds = fDataRate; fDataRate=0; return ds;}
-  std::map<int, long> GetDataPerChan();
+  int GetDataSize(){int ds = fDataRate; fDataRate=0; return ds;}
+  std::map<int, int> GetDataPerChan();
   bool CheckErrors();
   void CheckError(int bid) {fCheckFails[bid] = true;}
   int OpenProcessingThreads();
@@ -75,7 +75,7 @@ private:
   std::mutex fBufferMutex;
   std::mutex fMapMutex;
 
-  bool fReadLoop;
+  std::atomic_bool fReadLoop;
   int fStatus;
   int fNProcessingThreads;
   std::string fHostname;
@@ -83,7 +83,7 @@ private:
   Options *fOptions;
 
   // For reporting to frontend
-  std::atomic_uint64_t fBufferSize;
+  std::atomic_int fBufferSize;
   std::atomic_int fBufferLength;
   std::atomic_int fDataRate;
   std::map<int, V1724*> fBoardMap;

--- a/DAQController.hh
+++ b/DAQController.hh
@@ -46,7 +46,7 @@ public:
   void ReadData(int link);
   void End();
 
-  int GetData(std::list<data_packet> &ret);
+  int GetData(std::list<data_packet> &retVec);
     
   // Static wrapper so we can call ReadData in a std::thread
   void ReadThreadWrapper(void* data, int link);

--- a/DAQController.hh
+++ b/DAQController.hh
@@ -37,7 +37,7 @@ public:
     return fStatus;
   };
   int buffer_length(){
-    return fBufferLength;
+    return fBufferSize;
   };
   std::string run_mode();
   

--- a/DAQController.hh
+++ b/DAQController.hh
@@ -46,7 +46,8 @@ public:
   void ReadData(int link);
   void End();
 
-  int GetData(std::list<data_packet> &retVec);
+  int GetData(std::list<data_packet*> &retVec);
+  int GetData(data_packet* &dp);
     
   // Static wrapper so we can call ReadData in a std::thread
   void ReadThreadWrapper(void* data, int link);
@@ -64,14 +65,13 @@ public:
   
 private:
 
-  void AppendData(std::vector<data_packet> &d);
   void InitLink(std::vector<V1724*>&, std::map<int, std::map<std::string, std::vector<double>>>&, int&);
   int FitBaselines(std::vector<V1724*>&, std::map<int, std::vector<u_int16_t>>&, int,
       std::map<int, std::map<std::string, std::vector<double>>>&);
   
   std::vector <processingThread> fProcessingThreads;  
   std::map<int, std::vector <V1724*>> fDigitizers;
-  std::list<data_packet> fBuffer;
+  std::list<data_packet*> fBuffer;
   std::mutex fBufferMutex;
   std::mutex fMapMutex;
 

--- a/Options.cc
+++ b/Options.cc
@@ -254,7 +254,7 @@ int Options::GetCrateOpt(CrateOptions &ret){
   return 0;
 }
 
-int Options::GetChannel(int bid, int cid){
+int16_t Options::GetChannel(int bid, int cid){
   std::string boardstring = std::to_string(bid);
   try{
     return bson_options["channels"][boardstring][cid].get_int32().value;

--- a/Options.hh
+++ b/Options.hh
@@ -86,7 +86,7 @@ public:
   int GetDAC(std::map<int, std::map<std::string, std::vector<double>>>& board_dacs, std::vector<int>& bids);
   int GetCrateOpt(CrateOptions &ret);
   int GetHEVOpt(HEVOptions &ret);
-  int GetChannel(int bid, int cid);
+  int16_t GetChannel(int bid, int cid);
   int GetNestedInt(std::string path, int default_value);
   std::vector<u_int16_t> GetThresholds(int board);
 

--- a/StraxInserter.cc
+++ b/StraxInserter.cc
@@ -33,7 +33,7 @@ StraxInserter::StraxInserter(){
 StraxInserter::~StraxInserter(){
   fActive = false;
   fLog->Entry(MongoLog::Local, "Processing time: %.1f ms, compression time: %.1f ms",
-      fProcTime.count()*0.001, fCompTime*0.001);
+      fProcTime.count()*0.001, fCompTime.count()*0.001);
 }
 
 int StraxInserter::Initialize(Options *options, MongoLog *log, DAQController *dataSource,
@@ -117,7 +117,7 @@ void StraxInserter::ParseDocuments(data_packet *dp){
 
       if (words_in_event < buff[idx]&0xFFFFFFF) {
         fLog->Entry(MongoLog::Local, "Board %i garbled event header at idx %i: %u/%u (%i)",
-            dp->bid, idx, buffer[idx]&0xFFFFFFF, total_words-idx, dp->vBLT.size());
+            dp->bid, idx, buff[idx]&0xFFFFFFF, total_words-idx, dp->vBLT.size());
       }
 
       if (fmt["channel_mask_msb_idx"] != -1) {
@@ -349,7 +349,7 @@ int StraxInserter::ReadAndInsertData(){
   std::list<data_packet*> b;
   data_packet* dp = nullptr;
   system_clock::time_point proc_start, proc_end;
-  duration<microseconds> sleep_time = duration<microseconds>(10);
+  microseconds sleep_time(10);
   if (fOptions->GetString("buffer_type", "dual") == "dual") {
     while(fActive){
       if (fDataSource->GetData(b)) {
@@ -359,7 +359,7 @@ int StraxInserter::ReadAndInsertData(){
           ParseDocuments(dp);
           delete dp;
           proc_end = system_clock::now();
-          fProcTime += duration<microseconds>(proc_end - proc_start);
+          fProcTime += duration_cast<microseconds>(proc_end - proc_start);
         }
         b.clear();
       } else
@@ -373,7 +373,7 @@ int StraxInserter::ReadAndInsertData(){
         ParseDocuments(dp);
         delete dp;
         proc_end = system_clock::now();
-        fProcTime += duration<microseconds>(proc_end - proc_start);
+        fProcTime += duration_cast<microseconds>(proc_end - proc_start);
       }
       std::this_thread::sleep_for(sleep_time);
     }

--- a/StraxInserter.cc
+++ b/StraxInserter.cc
@@ -412,6 +412,7 @@ int StraxInserter::ReadAndInsertData(){
         for (auto& dp : b) {
           proc_start = system_clock::now();
           ParseDocuments(dp);
+          fBytesProcessed += dp->size;
           delete dp;
           proc_end = system_clock::now();
           fBufferLength--;
@@ -427,6 +428,7 @@ int StraxInserter::ReadAndInsertData(){
         haddata = true;
         proc_start = system_clock::now();
         ParseDocuments(dp);
+        fBytesProcessed += dp->size;
         delete dp;
         proc_end = system_clock::now();
         fProcTime += duration_cast<microseconds>(proc_end - proc_start);

--- a/StraxInserter.cc
+++ b/StraxInserter.cc
@@ -325,14 +325,13 @@ void StraxInserter::ParseDocuments(data_packet &dp){
 
 
 int StraxInserter::ReadAndInsertData(){
-  data_packet dp;
   fActive = true;
   bool haddata=false;
   std::list<data_packet> b;
   while(fActive){
     if (fDataSource->GetData(b)) {
       haddata = true;
-      for (auto& db : b) {
+      for (auto& dp : b) {
         ParseDocuments(dp);
         delete[] dp.buff;
       }

--- a/StraxInserter.cc
+++ b/StraxInserter.cc
@@ -20,7 +20,7 @@ StraxInserter::StraxInserter(){
   fChunkLength=0x7fffffff; // DAQ magic number
   fChunkNameLength=6;
   fChunkOverlap = 0x2FAF080;
-  fFragmentLength=110*2;
+  fFragmentBytes=110*2;
   fStraxHeaderSize=31;
   fLog = NULL;
   fErrorBit = false;
@@ -31,6 +31,9 @@ StraxInserter::StraxInserter(){
 }
 
 StraxInserter::~StraxInserter(){
+  fActive = false;
+  fLog->Entry(MongoLog::Local, "Processing time: %.1f ms, compression time: %.1f ms",
+      fProcTime.count()*0.001, fCompTime*0.001);
 }
 
 int StraxInserter::Initialize(Options *options, MongoLog *log, DAQController *dataSource,
@@ -38,7 +41,7 @@ int StraxInserter::Initialize(Options *options, MongoLog *log, DAQController *da
   fOptions = options;
   fChunkLength = long(fOptions->GetDouble("strax_chunk_length", 5)*1e9); // default 5s
   fChunkOverlap = long(fOptions->GetDouble("strax_chunk_overlap", 0.5)*1e9); // default 0.5s
-  fFragmentLength = fOptions->GetInt("strax_fragment_length", 110*2);
+  fFragmentBytes = fOptions->GetInt("strax_fragment_length", 110*2);
   fCompressor = fOptions->GetString("compressor", "lz4");
   fHostname = hostname;
   fBoardFailCount = 0;
@@ -87,31 +90,38 @@ void StraxInserter::GetDataPerChan(std::map<int, int>& ret) {
   return;
 }
 
-void StraxInserter::ParseDocuments(data_packet &dp){
+void StraxInserter::ParseDocuments(data_packet *dp){
   
   // Take a buffer and break it up into one document per channel
   unsigned int max_channels = 16; // hardcoded to accomodate V1730
   
   // Unpack the things from the data packet
-  std::vector<u_int32_t> clock_counters(max_channels, dp.clock_counter);
+  std::vector<u_int32_t> clock_counters(max_channels, dp->clock_counter);
   std::vector<u_int32_t> last_times_seen(max_channels, 0xFFFFFFFF);
   
-  u_int32_t size = dp.size;
-  u_int32_t *buff = dp.buff;
+  u_int32_t size = dp->size;
+  u_int32_t *buff = dp->buff;
   int smallest_latest_index_seen = -1;
+  const int event_header_words = 4;
   
   u_int32_t idx = 0;
-  std::map<std::string, int> fmt = fFmt[dp.bid];
-  while(idx < size/sizeof(u_int32_t) && buff[idx] != 0xFFFFFFFF){
+  std::map<std::string, int> fmt = fFmt[dp->bid];
+  unsigned total_words = size/sizeof(u_int32_t);
+  while(idx < total_words && buff[idx] != 0xFFFFFFFF){
     
     if(buff[idx]>>28 == 0xA){ // 0xA indicates header at those bits
 
       // Get data from main header
-      u_int32_t words_in_event = buff[idx]&0xFFFFFFF;
+      u_int32_t words_in_event = std::min(buff[idx]&0xFFFFFFF, total_words-idx);
       u_int32_t channel_mask = (buff[idx+1]&0xFF);
 
+      if (words_in_event < buff[idx]&0xFFFFFFF) {
+        fLog->Entry(MongoLog::Local, "Board %i garbled event header at idx %i: %u/%u (%i)",
+            dp->bid, idx, buffer[idx]&0xFFFFFFF, total_words-idx, dp->vBLT.size());
+      }
+
       if (fmt["channel_mask_msb_idx"] != -1) {
-	channel_mask = ( ((buff[idx+2]>>24)&0xFF)<<8 ) | (buff[idx+1]&0xFF); 
+	channel_mask = ( ((buff[idx+2]>>24)&0xFF)<<8 ) | (buff[idx+1]&0xFF);
       }
       
       // Exercise for the reader: if you're modifying for V1730 add in the rest of the bits here!
@@ -122,32 +132,41 @@ void StraxInserter::ParseDocuments(data_packet &dp){
       // I've never seen this happen but afraid to put it into the mongo log
       // since this call is in a loop
       if(board_fail){
-        fDataSource->CheckError(dp.bid);
-	fFailCounter[dp.bid]++;
-        idx += 4;
+        fDataSource->CheckError(dp->bid);
+	fFailCounter[dp->bid]++;
+        idx += event_header_words;
         continue;
       }
-      
-      idx += 4; // skip header
+      unsigned event_start_idx = idx;
+      idx += event_header_words; // skip header
 
       for(unsigned int channel=0; channel<max_channels; channel++){
 	if(!((channel_mask>>channel)&1))
 	  continue;
 
 	// These defaults are valid for 'default' firmware where all channels same size
-	u_int32_t channel_words = (words_in_event - 4) / channels_in_event;
+	u_int32_t channel_words = (words_in_event-event_header_words) / channels_in_event;
 	u_int32_t channel_time = event_time;
 	u_int32_t channel_timeMSB; 
-	//u_int32_t baseline_ch;     
 
 	// Presence of a channel header indicates non-default firmware (DPP-DAW) so override
 	if(fmt["channel_header_words"] > 0){
-	  channel_words = (buff[idx]&0x7FFFFF)-fmt["channel_header_words"];
+	  channel_words = std::min(buff[idx]&0x7FFFFF, words_in_event - (idx - event_start_idx));
+          if (channel_words < (buff[idx]&0x7FFFFF)) {
+            fLog->Entry(MongoLog::Local, "Board %i ch %i garbled header at idx %i: %u/%u",
+                  dp->bid, channel, idx, buff[idx]&0x7FFFFF, words_in_event);
+          }
+          if (channel_words <= fmt["channel_header_words"]) {
+            fLog->Entry(MongoLog::Local, "Board %i ch %i empty (%i/%i)",
+                dp->bid, channel, channel_words, fmt["channel_header_words"]);
+            idx += (fmt["channel_header_words"]-channel_words);
+            continue;
+          }
+          channel_words -= fmt["channel_header_words"];
 	  channel_time = buff[idx+1]&0xFFFFFFFF;
 
 	  if (fmt["channel_time_msb_idx"] == 2) { 
 	    channel_timeMSB = buff[idx+2]&0xFFFF; 
-	    //baseline_ch = (buff[idx+2]>>16)&0x3FFF;  
 	  }
 	  
 	  idx += fmt["channel_header_words"];
@@ -159,12 +178,12 @@ void StraxInserter::ParseDocuments(data_packet &dp){
 	    // First, on the first instance of a channel we gotta check if
 	    // the channel clock rolled over BEFORE this clock and adjust the counter
 	    
-	    if(channel_time > 15e8 && dp.header_time<5e8 &&
+	    if(channel_time > 15e8 && dp->header_time<5e8 &&
 	       last_times_seen[channel] == 0xFFFFFFFF && clock_counters[channel]!=0){
 	      clock_counters[channel]--;
 	    }
 	    // Now check the opposite
-	    else if(channel_time <5e8 && dp.header_time > 15e8 &&
+	    else if(channel_time <5e8 && dp->header_time > 15e8 &&
 		    last_times_seen[channel] == 0xFFFFFFFF){
 	      clock_counters[channel]++;
 	    }
@@ -186,7 +205,6 @@ void StraxInserter::ParseDocuments(data_packet &dp){
 
 	 if (fmt["channel_time_msb_idx"] == 2) { 
 	   Time64 = fmt["ns_per_clk"]*( ( (unsigned long)channel_timeMSB<<(int)32) + channel_time); 
-	   //std::cout<<" Time64 " << Time64 << " (ns) -->    " << Time64/1.e+9 << " (sec) " << std::endl;
 	 }
 	 else { 
 	   Time64 = fmt["ns_per_clk"]*(((unsigned long)clock_counters[channel] <<
@@ -211,26 +229,26 @@ void StraxInserter::ParseDocuments(data_packet &dp){
 	// as FragmentLength
 	u_int16_t *payload = reinterpret_cast<u_int16_t*>(buff);
 	u_int32_t samples_in_channel = channel_words<<1;
-	u_int32_t index_in_sample = 0;
+	u_int32_t index_in_pulse = 0;
 	u_int32_t offset = idx*2;
 	u_int16_t fragment_index = 0;
-	int16_t cl = int16_t(fOptions->GetChannel(dp.bid, channel));
+	int16_t cl = fOptions->GetChannel(dp->bid, channel);
         fDataPerChan[cl] += samples_in_channel<<1;
 	// Failing to discern which channel we're getting data from seems serious enough to throw
 	if(cl==-1)
 	  throw std::runtime_error("Failed to parse channel map. I'm gonna just kms now.");
 	
-	while(index_in_sample < samples_in_channel){
+	while(index_in_pulse < samples_in_channel){
 	  std::string fragment;
 	  
 	  // How long is this fragment?
-	  u_int32_t max_sample = index_in_sample + fFragmentLength/2;
-	  u_int32_t samples_this_channel = fFragmentLength/2;
-	  if((unsigned int)(fFragmentLength/2 + (fragment_index*fFragmentLength/2)) >
+	  u_int32_t max_sample = index_in_pulse + fFragmentBytes/2;
+	  u_int32_t samples_this_channel = fFragmentBytes/2;
+	  if((unsigned int)(fFragmentBytes/2 + (fragment_index*fFragmentBytes/2)) >
 	     samples_in_channel){
-	    max_sample = index_in_sample + (samples_in_channel -
-					    (fragment_index*fFragmentLength/2));
-	    samples_this_channel = max_sample-index_in_sample;
+	    max_sample = index_in_pulse + (samples_in_channel -
+					    (fragment_index*fFragmentBytes/2));
+	    samples_this_channel = max_sample-index_in_pulse;
 	  }
 
 	  char *channelLoc = reinterpret_cast<char*> (&cl);
@@ -240,11 +258,11 @@ void StraxInserter::ParseDocuments(data_packet &dp){
 	  char *sampleWidth = reinterpret_cast<char*> (&sw);
 	  fragment.append(sampleWidth, 2);
 
-	  u_int64_t time_this_fragment = Time64 + (fFragmentLength>>1)*sw*fragment_index;
+	  u_int64_t time_this_fragment = Time64 + (fFragmentBytes>>1)*sw*fragment_index;
 	  char *pulseTime = reinterpret_cast<char*> (&time_this_fragment);
 	  fragment.append(pulseTime, 8);
 
-	  //u_int32_t ft = fFragmentLength/2;
+	  //u_int32_t ft = fFragmentBytes/2;
 	  char *fragmenttime = reinterpret_cast<char*> (&samples_this_channel);
 	  fragment.append(fragmenttime, 4);
 
@@ -266,14 +284,14 @@ void StraxInserter::ParseDocuments(data_packet &dp){
 	  fragment.append(reductionLevel, 1);
 
 	  // Copy the raw buffer
-	  if(samples_this_channel>fFragmentLength/2){
+	  if(samples_this_channel>fFragmentBytes/2){
 	    std::cout<<samples_this_channel<<"!"<<std::endl;
 	    exit(-1);
 	  }
 
-	  const char *data_loc = reinterpret_cast<const char*>(&(payload[offset+index_in_sample]));
+	  const char *data_loc = reinterpret_cast<const char*>(&(payload[offset+index_in_pulse]));
 	  fragment.append(data_loc, samples_this_channel*2);
-	  while(fragment.size()<fFragmentLength+fStraxHeaderSize)
+	  while(fragment.size()<fFragmentBytes+fStraxHeaderSize)
 	    fragment.append(reductionLevel, 1); // int(0) != int("0")
 
 	  //copy(data_loc, data_loc+(samples_this_channel*2),&(fragment[31]));
@@ -285,14 +303,14 @@ void StraxInserter::ParseDocuments(data_packet &dp){
 	  while(chunk_index.size() < fChunkNameLength)
 	    chunk_index.insert(0, "0");
 
-	  if(!nextpre){// && !prevpost){	      
+	  if(!nextpre){
 	    if(fFragments.find(chunk_index) == fFragments.end()){
 	      fFragments[chunk_index] = new std::string();
 	    }
 	    fFragments[chunk_index]->append(fragment);
             fFragmentSize[chunk_index] += fragment.size();
 	  }
-	  else{// if(nextpre){
+	  else{
 	    std::string nextchunk_index = std::to_string(chunk_id+1);
 	    while(nextchunk_index.size() < fChunkNameLength)
 	      nextchunk_index.insert(0, "0");
@@ -310,7 +328,7 @@ void StraxInserter::ParseDocuments(data_packet &dp){
             fFragmentSize[chunk_index+"_post"] += fragment.size();
 	  }
 	  fragment_index++;
-	  index_in_sample = max_sample;
+	  index_in_pulse = max_sample;
 	}
 	// Go to next channel
 	idx+=channel_words;
@@ -325,19 +343,40 @@ void StraxInserter::ParseDocuments(data_packet &dp){
 
 
 int StraxInserter::ReadAndInsertData(){
+  using namespace std::chrono;
   fActive = true;
   bool haddata=false;
-  std::list<data_packet> b;
-  while(fActive){
-    if (fDataSource->GetData(b)) {
-      haddata = true;
-      for (auto& dp : b) {
+  std::list<data_packet*> b;
+  data_packet* dp = nullptr;
+  system_clock::time_point proc_start, proc_end;
+  duration<microseconds> sleep_time = duration<microseconds>(10);
+  if (fOptions->GetString("buffer_type", "dual") == "dual") {
+    while(fActive){
+      if (fDataSource->GetData(b)) {
+        haddata = true;
+        for (auto& dp : b) {
+          proc_start = system_clock::now();
+          ParseDocuments(dp);
+          delete dp;
+          proc_end = system_clock::now();
+          fProcTime += duration<microseconds>(proc_end - proc_start);
+        }
+        b.clear();
+      } else
+        std::this_thread::sleep_for(sleep_time);
+    }
+  } else {
+    while (fActive) {
+      if (fDataSource->GetData(dp)) {
+        haddata = true;
+        proc_start = system_clock::now();
         ParseDocuments(dp);
-        delete[] dp.buff;
+        delete dp;
+        proc_end = system_clock::now();
+        fProcTime += duration<microseconds>(proc_end - proc_start);
       }
-      b.clear();
-    } else
-      usleep(10); // 10us sleep
+      std::this_thread::sleep_for(sleep_time);
+    }
   }
   if(haddata)
     WriteOutFiles(1000000, true);
@@ -354,8 +393,9 @@ static const LZ4F_preferences_t kPrefs = {
 
 void StraxInserter::WriteOutFiles(int smallest_index_seen, bool end){
   // Write the contents of fFragments to blosc-compressed files
-
+  using namespace std::chrono;
   std::map<std::string, std::string*>::iterator iter;
+  system_clock::time_point comp_start, comp_end;
   for(iter=fFragments.begin();
       iter!=fFragments.end(); iter++){
     std::string chunk_index = iter->first;
@@ -364,6 +404,7 @@ void StraxInserter::WriteOutFiles(int smallest_index_seen, bool end){
     if(!(idnrint < smallest_index_seen-1 || end))    
       continue;
     
+    comp_start = system_clock::now();
     if(!fs::exists(GetDirectoryPath(chunk_index, true)))
       fs::create_directory(GetDirectoryPath(chunk_index, true));
 
@@ -403,6 +444,7 @@ void StraxInserter::WriteOutFiles(int smallest_index_seen, bool end){
     fs::rename(GetFilePath(chunk_index, true),
 	       GetFilePath(chunk_index, false));
     iter = fFragments.erase(iter);
+    fCompTime += duration<microseconds>(comp_end-comp_start);
     
     CreateMissing(idnrint);
   } // End for through fragments
@@ -488,4 +530,33 @@ void StraxInserter::CreateMissing(u_int32_t back_from_id){
     }
   }
   fMissingVerified = back_from_id;
+}
+
+
+data_packet::data_packet(int _s) {
+  if (_s > 0)
+    buff = new u_int32_t[_s/sizeof(u_int32_t)];
+  else
+    buff = nullptr;
+  size = _s;
+  clock_counter = 0;
+  header_time = 0;
+  bid = 0;
+}
+
+data_packet::~data_packet() {
+  if (buff != nullptr) delete[] buff;
+  buff = nullptr;
+  size = clock_counter = header_time = bid = 0;
+  vBLT.clear();
+}
+
+data_packet data_packet::operator=(const data_packet& rhs) {
+  if (buff != nullptr) delete[] buff;
+  buff = rhs.buff;
+  size = rhs.size;
+  clock_counter = rhs.clock_counter;
+  header_time = rhs.header_time;
+  bid = rhs.bid;
+  vBLT = rhs.vBLT;
 }

--- a/StraxInserter.cc
+++ b/StraxInserter.cc
@@ -34,10 +34,10 @@ StraxInserter::~StraxInserter(){
   fActive = false;
   int wait_counter = 0;
   fLog->Entry(MongoLog::Local, "Thread %x waiting to stop, has %i events left",
-      fThreadId, fBufferLength);
-  while (fRunning && wait_counter++ < 50)
+      fThreadId, fBufferLength.load());
+  while (fRunning && wait_counter++ < 500)
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
-  if (wait_counter >= 50)
+  if (wait_counter >= 500)
     fLog->Entry(MongoLog::Warning, "Thread %x taking a while to stop", fThreadId);
   fLog->Entry(MongoLog::Local, "Processing time: %.1f s, compression time: %.1f s",
       fProcTime.count()*1e-6, fCompTime.count()*1e-6);

--- a/StraxInserter.cc
+++ b/StraxInserter.cc
@@ -544,6 +544,16 @@ data_packet::data_packet(int _s) {
   bid = 0;
 }
 
+data_packet::data_packet(const data_packet& rhs) {
+  if (buff != nullptr) delete[] buff;
+  buff = rhs.buff;
+  size = rhs.size;
+  clock_counter = rhs.clock_counter;
+  header_time = rhs.header_time;
+  bid = rhs.bid;
+  vBLT = rhs.vBLT;
+}
+
 data_packet::~data_packet() {
   if (buff != nullptr) delete[] buff;
   buff = nullptr;

--- a/StraxInserter.cc
+++ b/StraxInserter.cc
@@ -355,7 +355,7 @@ int StraxInserter::ReadAndInsertData(){
   fActive = fRunning = true;
   bool haddata=false;
   std::list<data_packet> b;
-  data_packet dp = nullptr;
+  data_packet dp;
   system_clock::time_point proc_start, proc_end;
   microseconds sleep_time(10);
   if (fOptions->GetString("buffer_type", "dual") == "dual") {

--- a/StraxInserter.cc
+++ b/StraxInserter.cc
@@ -586,13 +586,13 @@ data_packet::~data_packet() {
   vBLT.clear();
 }
 
-data_packet& data_packet::operator=(const data_packet&& rhs) {
+data_packet& data_packet::operator=(data_packet&& rhs) {
   if (buff != nullptr) delete[] buff;
-  buff = rhs.buff;
-  size = rhs.size;
-  clock_counter = rhs.clock_counter;
-  header_time = rhs.header_time;
-  bid = rhs.bid;
-  vBLT = rhs.vBLT;
+  buff = rhs.buff; rhs.buff = nullptr;
+  size = rhs.size; rhs.size = 0;
+  clock_counter = rhs.clock_counter; rhs.clock_counter = 0;
+  header_time = rhs.header_time; rhs.header_time = 0;
+  bid = rhs.bid; rhs.bid = 0;
+  vBLT = rhs.vBLT; rhs.vBLT.clear();
   return *this;
 }

--- a/StraxInserter.cc
+++ b/StraxInserter.cc
@@ -533,12 +533,9 @@ void StraxInserter::CreateMissing(u_int32_t back_from_id){
 }
 
 
-data_packet::data_packet(int _s) {
-  if (_s > 0)
-    buff = new u_int32_t[_s/sizeof(u_int32_t)];
-  else
-    buff = nullptr;
-  size = _s;
+data_packet::data_packet() {
+  buff = nullptr;
+  size = 0;
   clock_counter = 0;
   header_time = 0;
   bid = 0;

--- a/StraxInserter.cc
+++ b/StraxInserter.cc
@@ -196,7 +196,7 @@ void StraxInserter::ParseDocuments(data_packet *dp){
 	    last_times_seen[channel] = channel_time;
 	    
 	  }
-	}
+	} // channel_header_words > 0
 
 	// Exercise for reader. This is for our 30-bit trigger clock. If yours was, say,
 	// 48 bits this line would be different
@@ -559,4 +559,5 @@ data_packet data_packet::operator=(const data_packet& rhs) {
   header_time = rhs.header_time;
   bid = rhs.bid;
   vBLT = rhs.vBLT;
+  return *this;
 }

--- a/StraxInserter.cc
+++ b/StraxInserter.cc
@@ -115,7 +115,7 @@ void StraxInserter::ParseDocuments(data_packet *dp){
       u_int32_t words_in_event = std::min(buff[idx]&0xFFFFFFF, total_words-idx);
       u_int32_t channel_mask = (buff[idx+1]&0xFF);
 
-      if (words_in_event < buff[idx]&0xFFFFFFF) {
+      if (words_in_event < (buff[idx]&0xFFFFFFF)) {
         fLog->Entry(MongoLog::Local, "Board %i garbled event header at idx %i: %u/%u (%i)",
             dp->bid, idx, buff[idx]&0xFFFFFFF, total_words-idx, dp->vBLT.size());
       }
@@ -444,7 +444,7 @@ void StraxInserter::WriteOutFiles(int smallest_index_seen, bool end){
     fs::rename(GetFilePath(chunk_index, true),
 	       GetFilePath(chunk_index, false));
     iter = fFragments.erase(iter);
-    fCompTime += duration<microseconds>(comp_end-comp_start);
+    fCompTime += duration_cast<microseconds>(comp_end-comp_start);
     
     CreateMissing(idnrint);
   } // End for through fragments

--- a/StraxInserter.cc
+++ b/StraxInserter.cc
@@ -336,11 +336,6 @@ void StraxInserter::ParseDocuments(data_packet* dp){
 	  fragment.append(reductionLevel, 1);
 
 	  // Copy the raw buffer
-	  if(samples_this_channel>fFragmentBytes/2){
-	    std::cout<<samples_this_channel<<"!"<<std::endl;
-	    exit(-1);
-	  }
-
 	  const char *data_loc = reinterpret_cast<const char*>(&(payload[offset+index_in_pulse]));
 	  fragment.append(data_loc, samples_this_channel*2);
 	  while(fragment.size()<fFragmentBytes+fStraxHeaderSize)

--- a/StraxInserter.cc
+++ b/StraxInserter.cc
@@ -33,7 +33,7 @@ StraxInserter::StraxInserter(){
 
 StraxInserter::~StraxInserter(){
   fActive = false;
-  int counter_sort = 0, counter_long = 0;
+  int counter_short = 0, counter_long = 0;
   fLog->Entry(MongoLog::Local, "Thread %x waiting to stop, has %i events left",
       fThreadId, fBufferLength.load());
   int events_start = fBufferLength.load();
@@ -42,7 +42,7 @@ StraxInserter::~StraxInserter(){
     while (fRunning && counter_short++ < 500)
       std::this_thread::sleep_for(std::chrono::milliseconds(10));
     if (counter_short >= 500)
-      fLog->Entry(MongoLog::Info, "Thread %x taking a while to stop, still has %i evts",
+      fLog->Entry(MongoLog::Message, "Thread %x taking a while to stop, still has %i evts",
           fThreadId, fBufferLength.load());
   } while (fBufferLength.load() > 0 && events_start > fBufferLength.load() && counter_long++ < 10);
   char prefix = ' ';

--- a/StraxInserter.cc
+++ b/StraxInserter.cc
@@ -248,7 +248,7 @@ void StraxInserter::ParseDocuments(data_packet* dp){
 	// will be beautiful. First we reinterpret the channel as 16
 	// bit because we want to allow also odd numbers of samples
 	// as FragmentLength
-	u_int16_t *payload = reinterpret_cast<u_int16_t*>(buff+idx);
+	u_int16_t *payload = reinterpret_cast<u_int16_t*>(buff);
 	u_int32_t samples_in_channel = channel_words<<1;
 	u_int32_t index_in_pulse = 0;
 	u_int32_t offset = idx*2;

--- a/StraxInserter.cc
+++ b/StraxInserter.cc
@@ -438,7 +438,7 @@ void StraxInserter::WriteOutFiles(int smallest_index_seen, bool end){
     int wsize = 0;
     if(fCompressor == "blosc"){
       out_buffer = new char[uncompressed_size+BLOSC_MAX_OVERHEAD];
-      wsize = blosc_compress_ctx(5, 1, sizeof(char), uncompressed_size,  iter.second,
+      wsize = blosc_compress_ctx(5, 1, sizeof(char), uncompressed_size,  iter.second->data(),
 				   out_buffer, uncompressed_size+BLOSC_MAX_OVERHEAD, "lz4", 0, 2);
     }
     else{
@@ -449,7 +449,7 @@ void StraxInserter::WriteOutFiles(int smallest_index_seen, bool end){
       size_t max_compressed_size = LZ4F_compressFrameBound(uncompressed_size, &kPrefs);
       out_buffer = new char[max_compressed_size];
       wsize = LZ4F_compressFrame(out_buffer, max_compressed_size,
-				 iter.second, uncompressed_size, &kPrefs);
+				 iter.second->data(), uncompressed_size, &kPrefs);
     }
     delete iter.second;
     iter.second = nullptr;

--- a/StraxInserter.cc
+++ b/StraxInserter.cc
@@ -388,6 +388,7 @@ void StraxInserter::WriteOutFiles(int smallest_index_seen, bool end){
 				 &((*iter->second)[0]), uncompressed_size, &kPrefs);
     }
     delete iter->second;
+    iter->second = nullptr;
     fFragmentSize[chunk_index] = 0;
     fFragmentSize.erase(chunk_index);
     
@@ -404,12 +405,11 @@ void StraxInserter::WriteOutFiles(int smallest_index_seen, bool end){
     iter = fFragments.erase(iter);
     
     CreateMissing(idnrint);
-    if(iter==fFragments.end())
-      break;
   } // End for through fragments
   
 
   if(end){
+    std::for_each(fFragments.begin(), fFragments.end(), [](auto p){if (p.second != nullptr) delete p.second;});
     fFragments.clear();
     fFragmentSize.clear();
     fs::path write_path(fOutputPath);

--- a/StraxInserter.hh
+++ b/StraxInserter.hh
@@ -54,7 +54,7 @@ public:
   void CheckError(int bid);
   
 private:
-  void ParseDocuments(data_packet *dp);
+  void ParseDocuments(data_packet &dp);
   void WriteOutFiles(int smallest_index_seen, bool end=false);
 
   std::experimental::filesystem::path GetFilePath(std::string id, bool temp);

--- a/StraxInserter.hh
+++ b/StraxInserter.hh
@@ -14,6 +14,7 @@
 #include <atomic>
 #include <vector>
 #include <chrono>
+#include <thread>
 
 class DAQController;
 class Options;
@@ -84,6 +85,7 @@ private:
 
   std::chrono::microseconds fProcTime;
   std::chrono::microseconds fCompTime;
+  std::thread::id fThreadId;
 };
 
 #endif

--- a/StraxInserter.hh
+++ b/StraxInserter.hh
@@ -12,6 +12,8 @@
 #include <experimental/filesystem>
 #include <numeric>
 #include <atomic>
+#include <vector>
+#include <chrono>
 
 class DAQController;
 class Options;
@@ -19,31 +21,16 @@ class MongoLog;
 
 struct data_packet{
   public:
-    data_packet() {buff = nullptr; size = clock_counter = header_time = bid = blt = 0;}
-    data_packet(const data_packet& rhs) {
-      buff = rhs.buff;
-      size = rhs.size;
-      clock_counter = rhs.clock_counter;
-      header_time = rhs.header_time;
-      bid = rhs.bid;
-      blt = rhs.blt;
-    }
-    ~data_packet() {buff = nullptr; size = clock_counter = header_time = bid = blt = 0;}
-    data_packet operator=(const data_packet& rhs) {
-      buff = rhs.buff;
-      size = rhs.size;
-      clock_counter = rhs.clock_counter;
-      header_time = rhs.header_time;
-      bid = rhs.bid;
-      blt = rhs.blt;
-      return *this;
-    }
-  u_int32_t *buff;
-  int32_t size;
-  u_int32_t clock_counter;
-  u_int32_t header_time;
-  int bid;
-  int blt;
+    data_packet(int _s = 0)
+    data_packet(const data_packet& rhs)
+    ~data_packet()
+    data_packet operator=(const data_packet& rhs)
+    u_int32_t *buff;
+    int32_t size;
+    u_int32_t clock_counter;
+    u_int32_t header_time;
+    int bid;
+    std::vector<int> vBLT;
 };
 
 
@@ -67,7 +54,7 @@ public:
   void CheckError(int bid);
   
 private:
-  void ParseDocuments(data_packet &dp);
+  void ParseDocuments(data_packet *dp);
   void WriteOutFiles(int smallest_index_seen, bool end=false);
 
   std::experimental::filesystem::path GetFilePath(std::string id, bool temp);
@@ -78,7 +65,7 @@ private:
 
   u_int64_t fChunkLength; // ns
   u_int32_t fChunkOverlap; // ns
-  u_int16_t fFragmentLength; // This is in BYTES
+  u_int16_t fFragmentBytes; // This is in BYTES
   u_int16_t fStraxHeaderSize; // in BYTES too
   u_int32_t fChunkNameLength;
   std::string fOutputPath, fHostname;
@@ -94,6 +81,9 @@ private:
   std::map<int, std::map<std::string, int>> fFmt;
   std::map<int, int> fFailCounter;
   std::map<int, std::atomic_int> fDataPerChan;
+
+  std::chrono::duration<std::chrono::microseconds> fProcTime;
+  std::chrono::duration<std::chrono::microseconds> fCompTime;
 };
 
 #endif

--- a/StraxInserter.hh
+++ b/StraxInserter.hh
@@ -80,6 +80,7 @@ private:
   std::map<int, std::map<std::string, int>> fFmt;
   std::map<int, int> fFailCounter;
   std::map<int, std::atomic_int> fDataPerChan;
+  std::atomic_int fBufferLength;
 
   std::chrono::microseconds fProcTime;
   std::chrono::microseconds fCompTime;

--- a/StraxInserter.hh
+++ b/StraxInserter.hh
@@ -30,7 +30,7 @@ struct data_packet{
     u_int32_t clock_counter;
     u_int32_t header_time;
     int bid;
-    std::vector<int> vBLT;
+    std::vector<u_int32_t> vBLT;
 };
 
 

--- a/StraxInserter.hh
+++ b/StraxInserter.hh
@@ -23,10 +23,7 @@ class MongoLog;
 struct data_packet{
   public:
     data_packet();
-    data_packet(const data_packet& rhs) = delete; // no copy ctor
-    data_packet(data_packet&& rhs);
     ~data_packet();
-    data_packet& operator=(data_packet&& rhs);
     u_int32_t *buff;
     int32_t size;
     u_int32_t clock_counter;

--- a/StraxInserter.hh
+++ b/StraxInserter.hh
@@ -60,7 +60,7 @@ public:
   int ReadAndInsertData();
   bool CheckError(){ return fErrorBit; }
   long GetBufferSize();
-  void GetDataPerChan(std::map<int, long>& ret);
+  void GetDataPerChan(std::map<int, int>& ret);
   void CheckError(int bid);
   
 private:
@@ -90,7 +90,7 @@ private:
   int fBoardFailCount;
   std::map<int, std::map<std::string, int>> fFmt;
   std::map<int, int> fFailCounter;
-  std::map<int, std::atomic_long> fDataPerChan;
+  std::map<int, std::atomic_int> fDataPerChan;
 };
 
 #endif

--- a/StraxInserter.hh
+++ b/StraxInserter.hh
@@ -72,7 +72,7 @@ private:
   Options *fOptions;
   MongoLog *fLog;
   DAQController *fDataSource;
-  std::atomic_bool fActive;
+  std::atomic_bool fActive, fRunning;
   bool fErrorBit;
   std::string fCompressor;
   std::map<std::string, std::string*> fFragments;

--- a/StraxInserter.hh
+++ b/StraxInserter.hh
@@ -51,6 +51,7 @@ public:
   long GetBufferSize();
   void GetDataPerChan(std::map<int, int>& ret);
   void CheckError(int bid);
+  int GetBufferLength() {return fBufferLength.load();}
   
 private:
   void ParseDocuments(data_packet *dp);
@@ -76,11 +77,11 @@ private:
   std::string fCompressor;
   std::map<std::string, std::string*> fFragments;
   std::map<std::string, std::atomic_long> fFragmentSize;
-  int fBoardFailCount;
   std::map<int, std::map<std::string, int>> fFmt;
   std::map<int, int> fFailCounter;
   std::map<int, std::atomic_int> fDataPerChan;
   std::atomic_int fBufferLength;
+  long fBytesProcessed;
 
   std::chrono::microseconds fProcTime;
   std::chrono::microseconds fCompTime;

--- a/StraxInserter.hh
+++ b/StraxInserter.hh
@@ -23,9 +23,10 @@ class MongoLog;
 struct data_packet{
   public:
     data_packet();
-    data_packet(const data_packet& rhs);
+    data_packet(const data_packet& rhs) = delete; // no copy ctor
+    data_packet(data_packet&& rhs);
     ~data_packet();
-    data_packet operator=(const data_packet& rhs);
+    data_packet& operator=(data_packet&& rhs);
     u_int32_t *buff;
     int32_t size;
     u_int32_t clock_counter;
@@ -55,7 +56,7 @@ public:
   void CheckError(int bid);
   
 private:
-  void ParseDocuments(data_packet &dp);
+  void ParseDocuments(data_packet *dp);
   void WriteOutFiles(int smallest_index_seen, bool end=false);
 
   std::experimental::filesystem::path GetFilePath(std::string id, bool temp);

--- a/StraxInserter.hh
+++ b/StraxInserter.hh
@@ -21,10 +21,10 @@ class MongoLog;
 
 struct data_packet{
   public:
-    data_packet(int _s = 0)
-    data_packet(const data_packet& rhs)
-    ~data_packet()
-    data_packet operator=(const data_packet& rhs)
+    data_packet(int _s = 0);
+    data_packet(const data_packet& rhs);
+    ~data_packet();
+    data_packet operator=(const data_packet& rhs);
     u_int32_t *buff;
     int32_t size;
     u_int32_t clock_counter;
@@ -82,8 +82,8 @@ private:
   std::map<int, int> fFailCounter;
   std::map<int, std::atomic_int> fDataPerChan;
 
-  std::chrono::duration<std::chrono::microseconds> fProcTime;
-  std::chrono::duration<std::chrono::microseconds> fCompTime;
+  std::chrono::microseconds fProcTime;
+  std::chrono::microseconds fCompTime;
 };
 
 #endif

--- a/StraxInserter.hh
+++ b/StraxInserter.hh
@@ -21,7 +21,7 @@ class MongoLog;
 
 struct data_packet{
   public:
-    data_packet(int _s = 0);
+    data_packet();
     data_packet(const data_packet& rhs);
     ~data_packet();
     data_packet operator=(const data_packet& rhs);

--- a/StraxInserter.hh
+++ b/StraxInserter.hh
@@ -19,21 +19,23 @@ class MongoLog;
 
 struct data_packet{
   public:
-    data_packet() {buff = nullptr; size = clock_counter = header_time = bid = 0;}
+    data_packet() {buff = nullptr; size = clock_counter = header_time = bid = blt = 0;}
     data_packet(const data_packet& rhs) {
       buff = rhs.buff;
       size = rhs.size;
       clock_counter = rhs.clock_counter;
       header_time = rhs.header_time;
       bid = rhs.bid;
+      blt = rhs.blt;
     }
-    ~data_packet() {buff = nullptr; size = clock_counter = header_time = bid = 0;}
+    ~data_packet() {buff = nullptr; size = clock_counter = header_time = bid = blt = 0;}
     data_packet operator=(const data_packet& rhs) {
       buff = rhs.buff;
       size = rhs.size;
       clock_counter = rhs.clock_counter;
       header_time = rhs.header_time;
       bid = rhs.bid;
+      blt = rhs.blt;
       return *this;
     }
   u_int32_t *buff;
@@ -41,6 +43,7 @@ struct data_packet{
   u_int32_t clock_counter;
   u_int32_t header_time;
   int bid;
+  int blt;
 };
 
 

--- a/V1724.cc
+++ b/V1724.cc
@@ -361,7 +361,7 @@ int V1724::SetThresholds(std::vector<u_int16_t> vals) {
 int V1724::End(){
   if(fBoardHandle>=0)
     CAENVME_End(fBoardHandle);
-  fBoardHandle=fLink=fCrate=fBID=-1;
+  fBoardHandle=fLink=fCrate=-1;
   fBaseAddress=0;
   return 0;
 }

--- a/V1724.cc
+++ b/V1724.cc
@@ -271,7 +271,7 @@ int V1724::ReadMBLT(u_int32_t* &buffer, std::vector<unsigned int>* v){
 
   int count = 0;
   u_int32_t* thisBLT = nullptr;
-  float safety_factor = 1.1; // should handle nonsense
+  float safety_factor = 1.2; // should handle nonsense
   do{
 
     // Reserve space for this block transfer

--- a/V1724.cc
+++ b/V1724.cc
@@ -300,7 +300,7 @@ int V1724::ReadMBLT(u_int32_t* &buffer, std::vector<unsigned int>* v){
 	delete[] transferred_buffers[x];
       return -1;
     }
-    if (nb > BLT_SIZE) fLog->Entry(MongoLog::Info,
+    if (nb > BLT_SIZE) fLog->Entry(MongoLog::Message,
         "Board %i got %i more bytes than asked for", fBID, nb-BLT_SIZE);
 
     count++;

--- a/V1724.cc
+++ b/V1724.cc
@@ -251,7 +251,7 @@ int64_t V1724::ReadMBLT(unsigned int *&buffer, int& blts){
   // The best-equipped V1724E has 4MS/channel memory = 8 MB/channel
   // the other, V1724G, has 512 MS/channel = 1MB/channel
   //unsigned int BLT_SIZE=8388608; //8*8388608; // 8MB buffer size
-  unsigned int BLT_SIZE=524288;
+  unsigned int BLT_SIZE=524288*8; // full thing
   std::vector<u_int32_t*> transferred_buffers;
   std::vector<u_int32_t> transferred_bytes;
 
@@ -302,8 +302,8 @@ int64_t V1724::ReadMBLT(unsigned int *&buffer, int& blts){
   // In tests this does not seem to impact our ability to read out the V1724 at the
   // maximum bandwidth of the link.
   if(blt_bytes>0){
-    buffer = new u_int32_t[blt_bytes/sizeof(u_int32_t)];
     u_int32_t bytes_copied = 0;
+    buffer = new u_int32_t[int(blt_bytes/sizeof(u_int32_t)*1.2)];
     for(unsigned int x=0; x<transferred_buffers.size(); x++){
       std::memcpy(((unsigned char*)buffer)+bytes_copied,
 		  transferred_buffers[x], transferred_bytes[x]);

--- a/V1724.cc
+++ b/V1724.cc
@@ -244,7 +244,7 @@ unsigned int V1724::ReadRegister(unsigned int reg){
   return temp;
 }
 
-int64_t V1724::ReadMBLT(unsigned int *&buffer){
+int64_t V1724::ReadMBLT(unsigned int *&buffer, int& blts){
   // Initialize
   int64_t blt_bytes=0;
   int nb=0,ret=-5;
@@ -290,8 +290,7 @@ int64_t V1724::ReadMBLT(unsigned int *&buffer){
     transferred_bytes.push_back(nb);
 
   }while(ret != cvBusError);
-
-
+  blts = count;
 
   // Now, unfortunately we need to make one copy of the data here or else our memory
   // usage explodes. We declare above a buffer of several MB, which is the maximum capacity

--- a/V1724.cc
+++ b/V1724.cc
@@ -9,6 +9,7 @@
 #include <iostream>
 #include "MongoLog.hh"
 #include "Options.hh"
+#include "StraxInserter.hh"
 #include <CAENVMElib.h>
 #include <chrono>
 #include <sstream>

--- a/V1724.hh
+++ b/V1724.hh
@@ -15,7 +15,7 @@ class V1724{
   virtual ~V1724();
 
   int Init(int link, int crate, int bid, unsigned int address=0);
-  int64_t ReadMBLT(u_int32_t *&buffer);
+  int64_t ReadMBLT(u_int32_t *&buffer, int& blts);
   int WriteRegister(unsigned int reg, unsigned int value);
   unsigned int ReadRegister(unsigned int reg);
   int GetClockCounter(u_int32_t timestamp);

--- a/V1724.hh
+++ b/V1724.hh
@@ -7,6 +7,7 @@
 
 class MongoLog;
 class Options;
+class data_packet;
 
 class V1724{
 
@@ -15,7 +16,7 @@ class V1724{
   virtual ~V1724();
 
   int Init(int link, int crate, int bid, unsigned int address=0);
-  int64_t ReadMBLT(u_int32_t *&buffer, int& blts);
+  int ReadMBLT(data_packet *dp);
   int WriteRegister(unsigned int reg, unsigned int value);
   unsigned int ReadRegister(unsigned int reg);
   int GetClockCounter(u_int32_t timestamp);
@@ -61,6 +62,9 @@ protected:
   unsigned int fReadoutStatusRegister;
   unsigned int fVMEAlignmentRegister;
   unsigned int fBoardErrRegister;
+
+  int BLT_SIZE;
+  std::map<int, long> blt_counts;
 
   bool MonitorRegister(u_int32_t reg, u_int32_t mask, int ntries,
 		       int sleep, u_int32_t val=1);

--- a/V1724.hh
+++ b/V1724.hh
@@ -16,7 +16,7 @@ class V1724{
   virtual ~V1724();
 
   int Init(int link, int crate, int bid, unsigned int address=0);
-  int ReadMBLT(data_packet *dp);
+  int ReadMBLT(u_int32_t* &buffer, std::vector<unsigned int>* v=nullptr);
   int WriteRegister(unsigned int reg, unsigned int value);
   unsigned int ReadRegister(unsigned int reg);
   int GetClockCounter(u_int32_t timestamp);

--- a/main.cc
+++ b/main.cc
@@ -248,7 +248,7 @@ int main(int argc, char** argv){
 	  }
 	  else
 	    logger->Entry(MongoLog::Warning, "Cannot arm DAQ while not 'Idle'");
-	}
+	} else if (command == "quit") b_run = false;
       }
     }
     catch(const std::exception &e){
@@ -282,6 +282,7 @@ int main(int argc, char** argv){
     }
     usleep(1000000);
   }
+  delete controller;
   delete logger;
   exit(0);
   


### PR DESCRIPTION
This PR strikes a Faustian pact and replaces all the stack instances of `data_packet` with pointers. During testing, catastrophic memory leaks were introduced and plugged. This should reduce most of the overhead with object creation and assignment.

Also, this PR adds some sanity checking to the output processing to make sure that we catch cases where boards decide not to return all the data from an event, some benchmarking tools to see what fraction of the time is spent processing events versus compressing them, and support for both dual buffers (a StraxInserter gets a list of packets to process) and single buffers (a StraxInserter gets one packet at a time).