### PR TITLE
Adds new diagnostic options and output

### DIFF
--- a/DAQController.cc
+++ b/DAQController.cc
@@ -341,7 +341,7 @@ int DAQController::GetData(std::list<data_packet*> &retVec, unsigned num){
     fBufferMutex.unlock();
     return 0;
   }
-  if (num == 0) num == std::max(16, fBufferLength >> 4);
+  if (num == 0) num = std::max(16, fBufferLength >> 4);
   if (num == 0) {
     retVec.splice(retVec.end(), fBuffer);
     fBufferLength = 0;

--- a/StraxInserter.hh
+++ b/StraxInserter.hh
@@ -80,6 +80,7 @@ private:
   std::map<int, std::map<std::string, int>> fFmt;
   std::map<int, int> fFailCounter;
   std::map<int, std::atomic_int> fDataPerChan;
+  std::map<int, long> fBufferCounter;
   std::atomic_int fBufferLength;
   long fBytesProcessed;
 

--- a/V1724.hh
+++ b/V1724.hh
@@ -64,7 +64,7 @@ protected:
   unsigned int fBoardErrRegister;
 
   int BLT_SIZE;
-  std::map<int, long> blt_counts;
+  std::map<int, long> fBLTCounter;
 
   bool MonitorRegister(u_int32_t reg, u_int32_t mask, int ntries,
 		       int sleep, u_int32_t val=1);
@@ -80,6 +80,8 @@ protected:
   bool seen_over_15;
 
   MongoLog *fLog;
+
+  float fBLTSafety, fBufferSafety;
 
 };
 


### PR DESCRIPTION
StraxInserters now keep track of the number of events they get whenever they ask the DAQController for data. This is output in the destructor. Additionally, a number of digitizer-config options are now supported. These include:
- `blt_size`: int, default 512 kiB. The number of bytes to allocate for BLTs.
- `blt_safety_factor`: float, default 1.5. How much extra memory to allocate for BLTs (sometimes the digitizer gives you more than you ask for, especially when reading large events)
- `buffer_safety_factor`: float, default 1.1. How much extra memory to allocate for the aggregated readout buffer.
- `do_sn_check`: int, default 0. Whether or not to check the board's serial number against what the config file says it should be.