### PR TITLE
One thread per board

### DIFF
--- a/DAQController.cc
+++ b/DAQController.cc
@@ -223,6 +223,7 @@ void DAQController::End(){
 		p.second.size(), p.first);
       while (p.second.size() > 0) {
         delete p.second.front();
+        p.second.pop();
       }
     }
   }
@@ -355,7 +356,8 @@ bool DAQController::CheckErrors(){
 
   for(unsigned int i=0; i<fProcessingThreads.size(); i++){
     if(fProcessingThreads[i].inserter->CheckError()){
-      fLog->Entry(MongoLog::Error, "Error found in processing thread.");
+      fLog->Entry(MongoLog::Error, "Error found in processing thread %i.",
+          fProcessingThreads[i].inserter->ID());
       fStatus=DAXHelpers::Error;
       return true;
     }

--- a/DAQController.cc
+++ b/DAQController.cc
@@ -222,8 +222,7 @@ void DAQController::End(){
       fLog->Entry(MongoLog::Warning, "Deleting uncleared buffer of size %i from board %i",
 		p.second.size(), p.first);
       while (p.second.size() > 0) {
-        data_packet* dp = p.front();
-        delete dp;
+        delete p.second.front();
       }
     }
   }
@@ -311,7 +310,7 @@ long DAQController::GetStraxBufferSize() {
 
 int DAQController::GetBufferLength() {
   int redax_buffer = std::accumulate(fBufferLength.begin(), fBufferLength.end(), 0,
-      [&](int tot, std::atomic_int& l) {return tot + l.load();});
+      [&](int tot, auto& p) {return tot + p.second.load();});
 
   int strax_buffer = std::accumulate(fProcessingThreads.begin(),
       fProcessingThreads.end(), 0,

--- a/StraxInserter.cc
+++ b/StraxInserter.cc
@@ -93,8 +93,8 @@ int StraxInserter::Initialize(Options *options, MongoLog *log, int bid,
   fErrorBit = false;
   fBytesProcessed = 0;
   int max_channels = 16;
-  mLastTimeSeen = std::vector<u_int32_t>(max_channels+1, 0);
-  mClockRollovers = std::vector<long>(max_channels+1, 0);
+  fLastTimeSeen = std::vector<u_int32_t>(max_channels+1, 0);
+  fClockRollovers = std::vector<long>(max_channels+1, 0);
   // we add 1 to the size to also track the event timestamp
 
   fProcTime = std::chrono::microseconds(0);
@@ -152,6 +152,7 @@ int64_t StraxInserter::HandleClockRollovers(int ch, u_int32_t ts) {
         fBID, ch, fLastTimeSeen[ch], ts, fClockRollovers[ch]);
   }
   fLastTimeSeen[ch] = ts;
+  iBitShift = 31;
   return (fClockRollovers[ch] << iBitShift) + ts;
 }
 

--- a/StraxInserter.cc
+++ b/StraxInserter.cc
@@ -29,6 +29,7 @@ StraxInserter::StraxInserter(){
   fChunkNameLength = 6;
   fBytesProcessed = 0;
   fBID = -1;
+  fFailCounter = 0;
 }
 
 StraxInserter::~StraxInserter(){

--- a/StraxInserter.cc
+++ b/StraxInserter.cc
@@ -457,6 +457,7 @@ int StraxInserter::ReadAndInsertData(){
   }
   if(haddata)
     WriteOutFiles(1000000, true);
+  fDataPerChan.clear();
   fRunning = false;
   return 0;
 }

--- a/StraxInserter.cc
+++ b/StraxInserter.cc
@@ -148,7 +148,7 @@ int64_t StraxInserter::HandleClockRollovers(int ch, u_int32_t ts) {
     fClockRollovers[ch]++;
   } else {
     // timestamps the same??
-    fLog->Entry(MongoLog::Info,
+    fLog->Entry(MongoLog::Message,
         "Something odd in timestamps on %i/%i: last %x, this %x, rollovers %i",
         fBID, ch, fLastTimeSeen[ch], ts, fClockRollovers[ch]);
   }
@@ -457,7 +457,7 @@ int StraxInserter::ReadAndInsertData(){
     }
   }
   if(haddata)
-    WriteOutFiles(1000000);
+    WriteOutFiles(1000000, true);
   End();
   fDataPerChan.clear();
   fRunning = false;
@@ -472,7 +472,7 @@ static const LZ4F_preferences_t kPrefs = {
     { 0, 0, 0 },  /* reserved, must be set to 0 */
 };
 
-void StraxInserter::WriteOutFiles(int smallest_index_seen){
+void StraxInserter::WriteOutFiles(int smallest_index_seen, bool end){
   // Write the contents of fFragments to blosc-compressed files
   using namespace std::chrono;
   system_clock::time_point comp_start, comp_end;

--- a/StraxInserter.cc
+++ b/StraxInserter.cc
@@ -152,7 +152,7 @@ int64_t StraxInserter::HandleClockRollovers(int ch, u_int32_t ts) {
         fBID, ch, fLastTimeSeen[ch], ts, fClockRollovers[ch]);
   }
   fLastTimeSeen[ch] = ts;
-  iBitShift = 31;
+  int iBitShift = 31;
   return (fClockRollovers[ch] << iBitShift) + ts;
 }
 

--- a/StraxInserter.hh
+++ b/StraxInserter.hh
@@ -57,7 +57,7 @@ public:
   
 private:
   void ParseDocuments(data_packet *dp);
-  void WriteOutFiles(int smallest_index_seen);
+  void WriteOutFiles(int smallest_index_seen, bool end = false);
   void End();
   int64_t HandleClockRollovers(int, u_int32_t);
   int AddFragmentToBuffer(std::string&, int64_t);

--- a/StraxInserter.hh
+++ b/StraxInserter.hh
@@ -44,7 +44,7 @@ public:
   StraxInserter();
   ~StraxInserter();
   
-  int  Initialize(Options *options, MongoLog *log, int bid
+  int  Initialize(Options *options, MongoLog *log, int bid,
 		  DAQController *dataSource, std::string hostname);
   void Close(std::map<int,int>& ret);
   

--- a/StraxInserter.hh
+++ b/StraxInserter.hh
@@ -49,14 +49,16 @@ public:
   void Close(std::map<int,int>& ret);
   
   int ReadAndInsertData();
-  bool CheckError(){ return fErrorBit; }
+  bool CheckError(){ bool ret = fErrorBit; fErrorBit = false; return ret; }
   long GetBufferSize();
   void GetDataPerChan(std::map<int, int>& ret);
   int GetBufferLength() {return fBufferLength.load();}
+  int ID() {return fBID;}
   
 private:
   void ParseDocuments(data_packet *dp);
-  void WriteOutFiles(int smallest_index_seen, bool end=false);
+  void WriteOutFiles(int smallest_index_seen);
+  void End();
   int64_t HandleClockRollovers(int, u_int32_t);
   int AddFragmentToBuffer(std::string&, int64_t);
   void GenerateArtificialDeadtime(int64_t);

--- a/V1724.hh
+++ b/V1724.hh
@@ -19,7 +19,6 @@ class V1724{
   int ReadMBLT(u_int32_t* &buffer, std::vector<unsigned int>* v=nullptr);
   int WriteRegister(unsigned int reg, unsigned int value);
   unsigned int ReadRegister(unsigned int reg);
-  int GetClockCounter(u_int32_t timestamp);
   int End();
 
   int bid(){
@@ -42,7 +41,6 @@ class V1724{
   bool EnsureStopped(int ntries, int sleep);
   int CheckErrors();
   u_int32_t GetAcquisitionStatus();
-  u_int32_t GetHeaderTime(u_int32_t *buff, u_int32_t size);
 
   std::map<std::string, int> DataFormatDefinition;
 


### PR DESCRIPTION
Processing threads now only handle data from one digitizer, rather than a grab-bag at random of whatever the DAQController's buffer held. This has the advantage that there's only ever one thread dealing with a given board's timestamps, so rollover counting is cleaner. Additionally, all data from one board is in one chunk, which might help track down problems leading to https://github.com/AxFoundation/strax/issues/119. To facilitate this, the DAQController now maintains one buffer and mutex per digitizer.

Also included in this PR is a longer-term way of handling garbled readout headers. In these situations, the responsible StraxInserter adds a fragment on the artificial deadtime channel. Also, the internal buffers were replaced with `std::queue` instances (sub-internally a `deque`, but we only process in a FIFO manner).