### PR TITLE
Strax cleanup

### DIFF
--- a/DAQController.hh
+++ b/DAQController.hh
@@ -8,7 +8,7 @@
 #include <vector>
 #include <cstdint>
 #include <mutex>
-#include <queue>
+#include <list>
 
 class StraxInserter;
 class MongoLog;
@@ -42,7 +42,7 @@ public:
   void ReadData(int link);
   void End();
 
-  int GetData(std::queue<data_packet*>* retVec, unsigned num = 0);
+  int GetData(std::list<data_packet*>* retQ, unsigned num = 0);
   int GetData(data_packet* &dp);
 
   int GetDataSize(){int ds = fDataRate; fDataRate=0; return ds;}
@@ -63,7 +63,7 @@ private:
 
   std::vector <processingThread> fProcessingThreads;
   std::map<int, std::vector <V1724*>> fDigitizers;
-  std::queue<data_packet*> fBuffer;
+  std::list<data_packet*> fBuffer;
   std::mutex fBufferMutex;
   std::mutex fMapMutex;
 

--- a/DAQController.hh
+++ b/DAQController.hh
@@ -8,7 +8,7 @@
 #include <vector>
 #include <cstdint>
 #include <mutex>
-#include <list>
+#include <queue>
 
 class StraxInserter;
 class MongoLog;
@@ -26,7 +26,7 @@ class DAQController{
     Main control interface for the DAQ. Control scripts and
     user-facing interfaces can call this directly.
   */
-  
+
 public:
   DAQController(MongoLog *log=NULL, std::string hostname="DEFAULT");
   ~DAQController();
@@ -36,18 +36,14 @@ public:
   int status(){return fStatus;}
   int GetBufferLength();
   std::string run_mode();
-  
+
   int Start();
   int Stop();
   void ReadData(int link);
   void End();
 
-  int GetData(std::list<data_packet*> &retVec, unsigned num = 0);
+  int GetData(std::queue<data_packet*>* retVec, unsigned num = 0);
   int GetData(data_packet* &dp);
-    
-  // Static wrapper so we can call ReadData in a std::thread
-  void ReadThreadWrapper(void* data, int link);
-  void ProcessingThreadWrapper(void* data);
 
   int GetDataSize(){int ds = fDataRate; fDataRate=0; return ds;}
   std::map<int, int> GetDataPerChan();
@@ -58,16 +54,16 @@ public:
   long GetStraxBufferSize();
 
   void GetDataFormat(std::map<int, std::map<std::string, int>>&);
-  
+
 private:
 
   void InitLink(std::vector<V1724*>&, std::map<int, std::map<std::string, std::vector<double>>>&, int&);
   int FitBaselines(std::vector<V1724*>&, std::map<int, std::vector<u_int16_t>>&, int,
       std::map<int, std::map<std::string, std::vector<double>>>&);
-  
-  std::vector <processingThread> fProcessingThreads;  
+
+  std::vector <processingThread> fProcessingThreads;
   std::map<int, std::vector <V1724*>> fDigitizers;
-  std::list<data_packet*> fBuffer;
+  std::queue<data_packet*> fBuffer;
   std::mutex fBufferMutex;
   std::mutex fMapMutex;
 

--- a/StraxInserter.cc
+++ b/StraxInserter.cc
@@ -356,7 +356,7 @@ void StraxInserter::ParseDocuments(data_packet* dp){
 	  fragment.append(data_loc, samples_this_fragment*2);
           uint8_t zero_filler = 0;
           char *zero = reinterpret_cast<char*> (&zero_filler);
-	  while(fragment.size()<fFragmentBytes+fStraxHeaderSize)
+	  while((int)fragment.size()<fFragmentBytes+fStraxHeaderSize)
 	    fragment.append(zero, 1); // int(0) != int("0")
 
           int chunk_id = AddFragmentToBuffer(fragment, time_this_fragment);

--- a/StraxInserter.hh
+++ b/StraxInserter.hh
@@ -47,7 +47,7 @@ public:
   void Close(std::map<int,int>& ret);
   
   int ReadAndInsertData();
-  bool CheckError(){ return fErrorBit; }
+  bool CheckError(){ return bool ret = fErrorBit; fErrorBit = false; return ret;}
   long GetBufferSize();
   void GetDataPerChan(std::map<int, int>& ret);
   void CheckError(int bid);
@@ -56,6 +56,8 @@ public:
 private:
   void ParseDocuments(data_packet *dp);
   void WriteOutFiles(int smallest_index_seen, bool end=false);
+  void GenerateAritificalDeadtime(int64_t timestamp);
+  int AddFragmentToBuffer(std::string& fragment, int64_t timestamp);
 
   std::experimental::filesystem::path GetFilePath(std::string id, bool temp);
   std::experimental::filesystem::path GetDirectoryPath(std::string id, bool temp);
@@ -63,11 +65,12 @@ private:
   void CreateMissing(u_int32_t back_from_id);
   int fMissingVerified;
 
-  u_int64_t fChunkLength; // ns
-  u_int32_t fChunkOverlap; // ns
-  u_int16_t fFragmentBytes; // This is in BYTES
-  u_int16_t fStraxHeaderSize; // in BYTES too
-  u_int32_t fChunkNameLength;
+  int64_t fChunkLength; // ns
+  int64_t fChunkOverlap; // ns
+  int16_t fFragmentBytes; // This is in BYTES
+  int16_t fStraxHeaderSize; // in BYTES too
+  int32_t fChunkNameLength;
+  int64_t fFullChunkLength;
   std::string fOutputPath, fHostname;
   Options *fOptions;
   MongoLog *fLog;

--- a/StraxInserter.hh
+++ b/StraxInserter.hh
@@ -47,7 +47,7 @@ public:
   void Close(std::map<int,int>& ret);
   
   int ReadAndInsertData();
-  bool CheckError(){ return bool ret = fErrorBit; fErrorBit = false; return ret;}
+  bool CheckError(){ bool ret = fErrorBit; fErrorBit = false; return ret;}
   long GetBufferSize();
   void GetDataPerChan(std::map<int, int>& ret);
   void CheckError(int bid);
@@ -67,9 +67,9 @@ private:
 
   int64_t fChunkLength; // ns
   int64_t fChunkOverlap; // ns
-  int16_t fFragmentBytes; // This is in BYTES
-  int16_t fStraxHeaderSize; // in BYTES too
-  int32_t fChunkNameLength;
+  int fFragmentBytes; // This is in BYTES
+  int fStraxHeaderSize; // in BYTES too
+  unsigned fChunkNameLength;
   int64_t fFullChunkLength;
   std::string fOutputPath, fHostname;
   Options *fOptions;

--- a/StraxInserter.hh
+++ b/StraxInserter.hh
@@ -56,7 +56,7 @@ public:
 private:
   void ParseDocuments(data_packet *dp);
   void WriteOutFiles(int smallest_index_seen, bool end=false);
-  void GenerateArtificalDeadtime(int64_t timestamp);
+  void GenerateArtificialDeadtime(int64_t timestamp);
   int AddFragmentToBuffer(std::string& fragment, int64_t timestamp);
 
   std::experimental::filesystem::path GetFilePath(std::string id, bool temp);

--- a/StraxInserter.hh
+++ b/StraxInserter.hh
@@ -56,7 +56,7 @@ public:
 private:
   void ParseDocuments(data_packet *dp);
   void WriteOutFiles(int smallest_index_seen, bool end=false);
-  void GenerateAritificalDeadtime(int64_t timestamp);
+  void GenerateArtificalDeadtime(int64_t timestamp);
   int AddFragmentToBuffer(std::string& fragment, int64_t timestamp);
 
   std::experimental::filesystem::path GetFilePath(std::string id, bool temp);


### PR DESCRIPTION
Fixes a critical bug in the strax output where the two length fields were swapped, and also moves some of the pulse processing into separate functions.

Additionally, if a garbled header comes through, the StraxInserter will insert a fragment on CH799 to indicate some deadtime is possible.