### PR TITLE
Store benchmarks in the database

### DIFF
--- a/Options.cc
+++ b/Options.cc
@@ -382,7 +382,7 @@ void SaveBenchmarks(std::map<std::string, long>& byte_counter,
   std::string run_id = GetString("run_identifier", "latest");
   auto search_doc = document{} << "run" << run_id << finalize;
   auto update_doc = document{};
-  update_doc << "$set" << "run" << run_id;
+  update_doc << "$set" << open_document << "run" << run_id << close_document;
   update_doc << "$push" << open_document;
   update_doc << "host" << fHostname;
   update_doc << "bytes" << byte_counter["bytes"];

--- a/Options.cc
+++ b/Options.cc
@@ -16,6 +16,7 @@ Options::Options(MongoLog *log, std::string options_name,
   fLog = log;
   mongocxx::uri uri{suri};
   fClient = mongocxx::client{uri};
+  fDBname = dbname;
   fDAC_collection = fClient[dbname]["dac_calibration"];
   mongocxx::collection opts_collection = fClient[dbname]["options"];
   if(Load(options_name, opts_collection, override_opts)!=0)
@@ -373,7 +374,31 @@ void Options::UpdateDAC(std::map<int, std::map<std::string, std::vector<double>>
   return;
 }
 
-void SaveBenchmarks(std::map<int, long>& buffer_counter, long bytes,
-    double proc_time_us, double comp_time_us, long tid) {
+void SaveBenchmarks(std::map<std::string, long>& byte_counter,
+    std::map<int, long>& buffer_counter, long bytes,
+    double proc_time_us, double comp_time_us) {
+  using namespace bsoncxx::builder::stream;
+  std::string run_id = GetString("run_identifier", "latest");
+  auto search_doc = document{} << "run" << run_id << finalize;
+  auto update_doc = document{};
+  update_doc << "$set" << "run" << run_id;
+  update_doc << "$push" << open_document;
+  update_doc << "bytes" << byte_counter["bytes"];
+  update_doc << "fragments" << byte_counter["fragments"];
+  update_doc << "events" << byte_counter["events"];
+  update_doc << "data_packets" << byte_counter["data_packets"];
+  update_doc << "processing_time_us" << proc_time_us;
+  update_doc << "compression_time_us" << comp_time_us;
+  update_doc << "buffer_xfers" << open_document;
+  for (auto& p : buffer_counter) {
+    update_doc << p.first << p.second;
+  }
+  update_doc << close_document; // buffer xfers
 
+  update_doc << close_document; // push
+  auto write_doc = update_doc << finalize;
+  mongocxx::options::update options;
+  options.upsert(true);
+  fClient[fDBname]["redax_benchmarks"].update_one(search_doc.view(), write_doc.view(), options);
+  return;
 }

--- a/Options.cc
+++ b/Options.cc
@@ -372,3 +372,8 @@ void Options::UpdateDAC(std::map<int, std::map<std::string, std::vector<double>>
   fDAC_collection.update_one(search_doc.view(), write_doc.view(), options);
   return;
 }
+
+void SaveBenchmarks(std::map<int, long>& buffer_counter, long bytes,
+    double proc_time_us, double comp_time_us, long tid) {
+
+}

--- a/Options.cc
+++ b/Options.cc
@@ -10,10 +10,11 @@
 #include <bsoncxx/builder/stream/document.hpp>
 #include <bsoncxx/exception/exception.hpp>
 
-Options::Options(MongoLog *log, std::string options_name,
+Options::Options(MongoLog *log, std::string options_name, std::string hostname,
           std::string suri, std::string dbname, std::string override_opts){
   bson_value = NULL;
   fLog = log;
+  fHostname = hostname;
   mongocxx::uri uri{suri};
   fClient = mongocxx::client{uri};
   fDBname = dbname;
@@ -383,6 +384,7 @@ void SaveBenchmarks(std::map<std::string, long>& byte_counter,
   auto update_doc = document{};
   update_doc << "$set" << "run" << run_id;
   update_doc << "$push" << open_document;
+  update_doc << "host" << fHostname;
   update_doc << "bytes" << byte_counter["bytes"];
   update_doc << "fragments" << byte_counter["fragments"];
   update_doc << "events" << byte_counter["events"];

--- a/Options.cc
+++ b/Options.cc
@@ -375,8 +375,8 @@ void Options::UpdateDAC(std::map<int, std::map<std::string, std::vector<double>>
   return;
 }
 
-void SaveBenchmarks(std::map<std::string, long>& byte_counter,
-    std::map<int, long>& buffer_counter, long bytes,
+void Options::SaveBenchmarks(std::map<std::string, long>& byte_counter,
+    std::map<int, long>& buffer_counter,
     double proc_time_us, double comp_time_us) {
   using namespace bsoncxx::builder::stream;
   std::string run_id = GetString("run_identifier", "latest");
@@ -393,7 +393,7 @@ void SaveBenchmarks(std::map<std::string, long>& byte_counter,
   update_doc << "compression_time_us" << comp_time_us;
   update_doc << "buffer_xfers" << open_document;
   for (auto& p : buffer_counter) {
-    update_doc << p.first << p.second;
+    update_doc << std::to_string(p.first) << p.second;
   }
   update_doc << close_document; // buffer xfers
 

--- a/Options.hh
+++ b/Options.hh
@@ -63,7 +63,7 @@ class MongoLog;
 class Options{
 
 public:
-  Options(MongoLog *log, std::string name, std::string suri,
+  Options(MongoLog *log, std::string name, std::string hostname, std::string suri,
   	std::string dbname, std::string override_opts);
   ~Options();
 
@@ -94,6 +94,7 @@ private:
   MongoLog *fLog;
   mongocxx::collection fDAC_collection;
   std::string fDBname;
+  std::string fHostname;
 };
 
 #endif

--- a/Options.hh
+++ b/Options.hh
@@ -86,6 +86,7 @@ public:
   std::vector<u_int16_t> GetThresholds(int board);
 
   void UpdateDAC(std::map<int, std::map<std::string, std::vector<double>>>&);
+  void SaveBenchmarks(std:map<int, long>&, long, double, double, long);
 private:
   mongocxx::client fClient;
   bsoncxx::document::view bson_options;

--- a/Options.hh
+++ b/Options.hh
@@ -86,13 +86,14 @@ public:
   std::vector<u_int16_t> GetThresholds(int board);
 
   void UpdateDAC(std::map<int, std::map<std::string, std::vector<double>>>&);
-  void SaveBenchmarks(std:map<int, long>&, long, double, double, long);
+  void SaveBenchmarks(std:map<std::string, long>&, std::map<int, long>& double, double);
 private:
   mongocxx::client fClient;
   bsoncxx::document::view bson_options;
   bsoncxx::document::value *bson_value;
   MongoLog *fLog;
   mongocxx::collection fDAC_collection;
+  std::string fDBname;
 };
 
 #endif

--- a/StraxInserter.cc
+++ b/StraxInserter.cc
@@ -183,6 +183,7 @@ void StraxInserter::ParseDocuments(data_packet* dp){
       u_int32_t channels_in_event = __builtin_popcount(channel_mask);
       bool board_fail = buff[idx+1]&0x4000000; // & (buff[idx+1]>>27)
       u_int32_t event_time = buff[idx+3]&0xFFFFFFFF;
+      fEventsProcessed++;
 
       if(board_fail){
         const std::lock_guard<std::mutex> lg(fFC_mutex);
@@ -318,6 +319,7 @@ void StraxInserter::ParseDocuments(data_packet* dp){
 					    (fragment_index*fragment_samples));
 	    samples_this_fragment = max_sample-index_in_pulse;
 	  }
+          fFragmentsProcessed++;
 
 	  u_int64_t time_this_fragment = Time64 + fragment_samples*sw*fragment_index;
 	  char *pulseTime = reinterpret_cast<char*> (&time_this_fragment);

--- a/StraxInserter.cc
+++ b/StraxInserter.cc
@@ -63,7 +63,7 @@ StraxInserter::~StraxInserter(){
     {"fragments", fFragmentsProcessed},
     {"events", fEventsProcessed},
     {"data_packets", total_dps}};
-  fOptions->SaveBenchmarkData(counters, fBufferCounter,
+  fOptions->SaveBenchmarks(counters, fBufferCounter,
       fProcTime.count(), fCompTime.count());
 }
 

--- a/StraxInserter.cc
+++ b/StraxInserter.cc
@@ -33,7 +33,6 @@ StraxInserter::StraxInserter(){
   fFullChunkLength = fChunkLength+fChunkOverlap;
   fFragmentsProcessed = 0;
   fEventsProcessed = 0;
-  fDataPacketsProcessed = 0;
 }
 
 StraxInserter::~StraxInserter(){
@@ -56,15 +55,14 @@ StraxInserter::~StraxInserter(){
         fThreadId, fBufferLength.load());
     fForceQuit = true;
   }
-  return;
-  char prefix = ' ';
-  float num = 0.;
+  long total_dps = std::accumulate(fBufferCounter.begin(), fBufferCounter.end(), 0,
+      [&](long tot, auto& p){return tot + p.second;});
   std::map<std::string, long> counters {
     {"bytes", fBytesProcessed},
     {"fragments", fFragmentsProcessed},
     {"events", fEventsProcessed},
-    {"datapackets", fDataPacketsProcessed}};
-  fOptions->SaveBenchmarkData(fThreadId, counters, fBufferCounter,
+    {"data_packets", total_dps}};
+  fOptions->SaveBenchmarkData(counters, fBufferCounter,
       fProcTime.count(), fCompTime.count());
 }
 

--- a/StraxInserter.hh
+++ b/StraxInserter.hh
@@ -88,6 +88,9 @@ private:
   std::map<int, long> fBufferCounter;
   std::atomic_int fBufferLength;
   long fBytesProcessed;
+  long fFragmentsProcessed;
+  long fEventsProcessed;
+  long fDataPacketsProcessed;
 
   std::chrono::microseconds fProcTime;
   std::chrono::microseconds fCompTime;

--- a/StraxInserter.hh
+++ b/StraxInserter.hh
@@ -90,7 +90,6 @@ private:
   long fBytesProcessed;
   long fFragmentsProcessed;
   long fEventsProcessed;
-  long fDataPacketsProcessed;
 
   std::chrono::microseconds fProcTime;
   std::chrono::microseconds fCompTime;

--- a/main.cc
+++ b/main.cc
@@ -248,7 +248,7 @@ int main(int argc, char** argv){
 	      fOptions = NULL;
 	    }
 	    fOptions = new Options(logger, (doc)["mode"].get_utf8().value.to_string(),
-				   suri, dbname, override_json);
+				   hostname, suri, dbname, override_json);
 	    std::vector<int> links;
 	    if(controller->InitializeElectronics(fOptions, links) != 0){
 	      logger->Entry(MongoLog::Error, "Failed to initialize electronics");


### PR DESCRIPTION
Rather than dump them to the logfiles and trawl through them to extract the useful information, each StraxInserter pushes its performance data to the database. Also, it now tracks how many events and fragments are processed, as well as data packets and bytes.