### PR TITLE
Some tweaks to end reduce end-of-run crashing

### DIFF
--- a/DAQController.cc
+++ b/DAQController.cc
@@ -105,7 +105,7 @@ int DAQController::InitializeElectronics(Options *options, std::vector<int>&keys
   if (fOptions->GetString("baseline_dac_mode") == "cached")
     fOptions->GetDAC(dac_values, BIDs);
   std::vector<std::thread*> init_threads;
-
+  fMaxEventsPerThread = fOptions->GetInt("max_events_per_thread", 1024);
   std::map<int,int> rets;
   // Parallel digitizer programming to speed baselining
   for( auto& link : fDigitizers ) {
@@ -343,7 +343,7 @@ int DAQController::GetData(std::list<data_packet*>* retQ, unsigned num){
   if (fBuffer.size() == 0) {
     return 0;
   }
-  if (num == 0) num = std::max(16, fBufferLength >> 4);
+  if (num == 0) num = std::max(16, std::min(fMaxEventsPerThread, fBufferLength >> 4));
   do {
     dp = fBuffer.front();
     fBuffer.pop_front();

--- a/DAQController.hh
+++ b/DAQController.hh
@@ -75,6 +75,7 @@ private:
   std::string fHostname;
   MongoLog *fLog;
   Options *fOptions;
+  int fMaxEventsPerThread;
 
   // For reporting to frontend
   std::atomic_int fBufferSize;

--- a/StraxInserter.cc
+++ b/StraxInserter.cc
@@ -472,6 +472,8 @@ void StraxInserter::WriteOutFiles(int smallest_index_seen, bool end){
   system_clock::time_point comp_start, comp_end;
   std::vector<std::string> idx_to_clear;
   for (auto& iter : fFragments) {
+    if (iter.first == "")
+        break; // not sure why, but this sometimes happens during bad shutdowns
     std::string chunk_index = iter.first;
     std::string idnr = chunk_index.substr(0, fChunkNameLength);
     int idnrint = std::stoi(idnr);
@@ -524,12 +526,12 @@ void StraxInserter::WriteOutFiles(int smallest_index_seen, bool end){
   } // End for through fragments
   // clear now because c++ sometimes overruns its buffers
   for (auto s : idx_to_clear) {
-    fFragments.erase(s);
+    if (fFragments.count(s) != 0) fFragments.erase(s);
   }
-  
 
   if(end){
-    std::for_each(fFragments.begin(), fFragments.end(), [](auto p){if (p.second != nullptr) delete p.second;});
+    for (auto& p : fFragments)
+        if (p.second != nullptr) delete p.second;
     fFragments.clear();
     fFragmentSize = 0;
     fs::path write_path(fOutputPath);


### PR DESCRIPTION
During run 7170, the DAQ was saturating the output stream (bad config), and the buffer too large to process and clear at the end of the run (multiple GB, O(10k) data packets/thread). This PR limits the maximum number of data packets one thread can request (set via `max_events_per_thread` config, default 1024), which should help responsiveness during the end-of-run sequence.