### PR TITLE
Fix for processing threads dying when being killed

### DIFF
--- a/StraxInserter.cc
+++ b/StraxInserter.cc
@@ -364,12 +364,12 @@ void StraxInserter::ParseDocuments(data_packet* dp){
 	
 	  fragment_index++;
 	  index_in_pulse = max_sample;
-          if (bForceQuit == true) break;
+          if (fForceQuit == true) break;
 	} // while in pulse
 	idx+=channel_words;
-        if (bForceQuit == true) break;
+        if (fForceQuit == true) break;
       } // channel loop
-      if (bForceQuit == true) break;
+      if (fForceQuit == true) break;
     } // if header
     else
       idx++;

--- a/StraxInserter.cc
+++ b/StraxInserter.cc
@@ -56,6 +56,10 @@ StraxInserter::~StraxInserter(){
     fForceQuit = true;
     std::this_thread::sleep_for(std::chrono::seconds(2));
   }
+  while (fRunning) {
+    fLog->Entry(MongoLog::Message, "Still waiting for thread %lx to stop", fThreadId);
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+  }
   long total_dps = std::accumulate(fBufferCounter.begin(), fBufferCounter.end(), 0,
       [&](long tot, auto& p){return tot + p.second;});
   std::map<std::string, long> counters {
@@ -360,11 +364,13 @@ void StraxInserter::ParseDocuments(data_packet* dp){
 	
 	  fragment_index++;
 	  index_in_pulse = max_sample;
-	}
-	// Go to next channel
+          if (bForceQuit == true) break;
+	} // while in pulse
 	idx+=channel_words;
-      }
-    }
+        if (bForceQuit == true) break;
+      } // channel loop
+      if (bForceQuit == true) break;
+    } // if header
     else
       idx++;
   }


### PR DESCRIPTION
If a StraxInserter gets its hands on too much data near the end of the run, it can still be working through it when the run ends. The master thread sends a Kill message to the worker thread, but it didn't wait long enough for the thread to finish what it was doing before cleaning up the StraxInserter's memory, which will cause a segfault. This PR fixes this crash by (a) having the Kill message registered at a deeper level, and (b) waiting unconditionally until the worker thread returns before cleanup.