### PR TITLE
Generates artificial deadtime if something goes wrong in the data

### DIFF
--- a/StraxInserter.hh
+++ b/StraxInserter.hh
@@ -56,7 +56,7 @@ public:
 private:
   void ParseDocuments(data_packet *dp);
   void WriteOutFiles(int smallest_index_seen, bool end=false);
-  void GenerateArtificialDeadtime(int64_t timestamp);
+  void GenerateArtificialDeadtime(int64_t timestamp, int16_t bid);
   int AddFragmentToBuffer(std::string& fragment, int64_t timestamp);
 
   std::experimental::filesystem::path GetFilePath(std::string id, bool temp);


### PR DESCRIPTION
Occasionally a board will return sloppy data, which has caused significant segfaults in the past. The simplest fix was to skip the garbage data and move on with only an entry in a logfile as evidence. With the expansion of the meta channels for strax, the better solution is to have redax write a fragment on an artificial deadtime channel so anything downstream knows that something failed in parsing.