### PR TITLE
Processes log when they ack commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ ccontrol
 # DAQ logs
 *.log
 log_*
+
+# python caches
+*__pycache__*

--- a/CControl_Handler.cc
+++ b/CControl_Handler.cc
@@ -83,12 +83,11 @@ int CControl_Handler::DeviceArm(int run, Options *opts){
 	fLog->Entry(MongoLog::Error, "Failed to pull DDC10 options from file");
      }
   } else {
-    fLog->Entry(MongoLog::Debug, "No HEV");
+    //fLog->Entry(MongoLog::Debug, "No HEV");
   }
 
 
-  // Getting options for the Muon Veto V1495 board
-  // Init V1495_MV only when included in config - Muon Veto only
+  // Getting options for the V1495 board
   std::vector<BoardType> mv = fOptions->GetBoards("V1495", fProcname);
   if (mv.size() == 1){
     BoardType mv_def = mv[0];
@@ -107,9 +106,9 @@ int CControl_Handler::DeviceArm(int run, Options *opts){
 		}
     }
   }else{
-    fLog->Entry(MongoLog::Debug, "No V1495");
+    //fLog->Entry(MongoLog::Debug, "No V1495");
   }
-  fLog->Entry(MongoLog::Local, "Arm sequence finished");
+  //fLog->Entry(MongoLog::Local, "Arm sequence finished");
   fStatus = DAXHelpers::Armed;
   return 0;
 
@@ -124,20 +123,20 @@ int CControl_Handler::DeviceStart(){
     fLog->Entry(MongoLog::Warning, "V2718 attempt to start without arming. Maybe unclean shutdown");
     return 0;
   }
-  if(fV2718 == NULL || fV2718->SendStartSignal()!=0){   
+  if(fV2718 == NULL || fV2718->SendStartSignal()!=0){
     fLog->Entry(MongoLog::Error, "V2718 either failed to start");
     fStatus = DAXHelpers::Error;
     return -1;
   }
 
   fStatus = DAXHelpers::Running;
-  fLog->Entry(MongoLog::Local, "Start sequence completed");
+  //fLog->Entry(MongoLog::Local, "Start sequence completed");
   return 0;
 }
 
 // Stopping the previously started devices; V2718, V1495, DDC10...
 int CControl_Handler::DeviceStop(){
-  fLog->Entry(MongoLog::Local, "Beginning stop sequence");
+  //fLog->Entry(MongoLog::Local, "Beginning stop sequence");
 
   // If V2718 here then send stop signal
   if(fV2718 != NULL){

--- a/CControl_Handler.cc
+++ b/CControl_Handler.cc
@@ -165,7 +165,7 @@ int CControl_Handler::DeviceStop(){
 
 // Reporting back on the status of V2718, V1495, DDC10 etc...
 bsoncxx::document::value CControl_Handler::GetStatusDoc(std::string hostname){
-  using namespace std::chrono
+  using namespace std::chrono;
  
   // Updating the status doc
   bsoncxx::builder::stream::document builder{};

--- a/DAQController.cc
+++ b/DAQController.cc
@@ -266,6 +266,7 @@ void DAQController::ReadData(int link){
         fCheckFails[digi->bid()] = false;
         err_val = fBoardMap[digi->bid()]->CheckErrors();
 	fLog->Entry(MongoLog::Local, "Error %i from board %i", err_val, digi->bid());
+        fStatus = DAXHelpers::Error; // stop command will be issued soon
         if (err_val == -1) {
 
         } else {
@@ -283,6 +284,7 @@ void DAQController::ReadData(int link){
           delete dp;
           dp = nullptr;
 	}
+        fStatus = DAXHelpers::Error;
 	break;
       }
       if(dp->size>0){

--- a/DAQController.cc
+++ b/DAQController.cc
@@ -520,11 +520,9 @@ int DAQController::FitBaselines(std::vector<V1724*> &digis,
   int min_adjustment = fOptions->GetInt("baseline_min_adjustment", 0xA);
   int rebin_factor = fOptions->GetInt("baseline_rebin_log2", 1); // log base 2
   int bins_around_max = fOptions->GetInt("baseline_bins_around_max", 3);
-  int nbins(1 << (14-rebin_factor)), bid(0);
-  int steps_repeated(0), max_repeated_steps(10);
+  int steps_repeated(0), max_repeated_steps(10), bid(0);
   int triggers_per_step = fOptions->GetInt("baseline_triggers_per_step", 3);
   std::chrono::milliseconds ms_between_triggers(fOptions->GetInt("baseline_ms_between_triggers", 10));
-  std::array<int, 0x4000> hist;
   vector<long> DAC_cal_points = {60000, 30000, 6000}; // arithmetic overflow
   std::map<int, vector<int>> channel_finished;
   std::map<int, u_int32_t*> buffers;
@@ -548,8 +546,6 @@ int DAQController::FitBaselines(std::vector<V1724*> &digis,
   u_int32_t words_in_event, channel_mask, words_per_channel, idx;
   u_int16_t val0, val1;
   int channels_in_event;
-  auto hist_start = hist.begin(), hist_end = hist.end();
-  auto max_it = hist.begin(), max_start = hist.begin(), max_end = hist.begin();
 
   for (int iter = 0; iter < max_iter; iter++) {
     if (done || fail) break;
@@ -666,7 +662,7 @@ int DAQController::FitBaselines(std::vector<V1724*> &digis,
             }
             channel_mask = buffers[bid][idx+1]&0xFF;
             if (d->DataFormatDefinition["channel_mask_msb_idx"] != -1) {
-              channel_mask = ( ((buffers[bid][idx+2]>>24)&0xFF)<<8 ) | (buffers[bid][idx+1]&0xFF); 
+              channel_mask |= ( ((buffers[bid][idx+2]>>24)&0xFF)<<8 );
             }
             if (channel_mask == 0) { // should be impossible?
               idx += 4;
@@ -680,7 +676,7 @@ int DAQController::FitBaselines(std::vector<V1724*> &digis,
             for (unsigned ch = 0; ch < d->GetNumChannels(); ch++) {
               if (!(channel_mask & (1 << ch))) continue;
               idx += d->DataFormatDefinition["channel_header_words"];
-              hist.fill(0);
+              vector<int> hist(0x4000, 0);
               for (unsigned w = 0; w < words_per_channel; w++) {
                 val0 = buffers[bid][idx+w]&0xFFFF;
                 val1 = (buffers[bid][idx+w]>>16)&0xFFFF;
@@ -689,24 +685,27 @@ int DAQController::FitBaselines(std::vector<V1724*> &digis,
                 hist[val1 >> rebin_factor]++;
               }
               idx += words_per_channel;
-              max_it = std::max_element(hist_start, hist_end);
-              max_start = std::max(max_it - bins_around_max, hist_start);
-              max_end = std::min(max_it + bins_around_max+1, hist_end);
-              counts_total = std::accumulate(hist_start, hist_end, 0);
+              auto max_it = std::max_element(hist.begin(), hist.end());
+              auto max_start = std::max(max_it - bins_around_max, hist.begin());
+              auto max_end = std::min(max_it + bins_around_max+1, hist.end());
+              counts_total = std::accumulate(hist.begin(), hist.end(), 0);
               counts_around_max = std::accumulate(max_start, max_end, 0);
               if (counts_around_max < fraction_around_max*counts_total) {
                 fLog->Entry(MongoLog::Local,
                     "Bd %i ch %i: %i out of %i counts around max %i",
                     bid, ch, counts_around_max, counts_total,
-                    std::distance(max_it, hist_start)<<rebin_factor);
+                    std::distance(hist.begin(), max_it)<<rebin_factor);
                 redo_iter = true;
               }
-              if (counts_total/words_per_channel < 1.5) //25% zeros
+              if (counts_total < 1.5*words_per_channel) {//25% zeros
                 redo_iter = true;
+                fLog->Entry(MongoLog::Local, "Bd %i ch %i too many skipped samples", bid, ch);
+              }
+              vector<int> bin_ids(std::distance(max_start, max_end), 0);
+              std::iota(bin_ids.begin(), bin_ids.end(), std::distance(hist.begin(), max_start));
               baseline = 0;
               // calculated weighted average
-              for (auto it = max_start; it < max_end; it++)
-                baseline += (std::distance(it, hist_start)<<rebin_factor)*(*it);
+              baseline = std::inner_product(max_start, max_end, bin_ids.begin(), 0) << rebin_factor;
               baseline /= counts_around_max;
               bl_per_channel[bid][ch][step] = baseline;
             } // for each channel

--- a/Options.cc
+++ b/Options.cc
@@ -379,7 +379,7 @@ void Options::SaveBenchmarks(std::map<std::string, long>& byte_counter,
     std::map<int, long>& buffer_counter,
     double proc_time_dp_us, double proc_time_ev_us, double proc_time_ch_us, double comp_time_us) {
   using namespace bsoncxx::builder::stream;
-  std::string run_id = GetString("run_identifier", "latest");
+  int run_id = std::stoi(GetString("run_identifier", "latest"));
   auto search_doc = document{} << "run" << run_id << finalize;
   auto update_doc = document{};
   update_doc << "$set" << open_document << "run" << run_id << close_document;

--- a/Options.cc
+++ b/Options.cc
@@ -379,7 +379,11 @@ void Options::SaveBenchmarks(std::map<std::string, long>& byte_counter,
     std::map<int, long>& buffer_counter,
     double proc_time_dp_us, double proc_time_ev_us, double proc_time_ch_us, double comp_time_us) {
   using namespace bsoncxx::builder::stream;
-  int run_id = std::stoi(GetString("run_identifier", "latest"));
+  int run_id = -1;
+  try{
+    run_id = std::stoi(GetString("run_identifier", "latest"));
+  } catch (...) {
+  }
   auto search_doc = document{} << "run" << run_id << finalize;
   auto update_doc = document{};
   update_doc << "$set" << open_document << "run" << run_id << close_document;

--- a/Options.cc
+++ b/Options.cc
@@ -377,7 +377,7 @@ void Options::UpdateDAC(std::map<int, std::map<std::string, std::vector<double>>
 
 void Options::SaveBenchmarks(std::map<std::string, long>& byte_counter,
     std::map<int, long>& buffer_counter,
-    double proc_time_us, double comp_time_us) {
+    double proc_time_dp_us, double proc_time_ev_us, double proc_time_ch_us, double comp_time_us) {
   using namespace bsoncxx::builder::stream;
   std::string run_id = GetString("run_identifier", "latest");
   auto search_doc = document{} << "run" << run_id << finalize;
@@ -389,7 +389,9 @@ void Options::SaveBenchmarks(std::map<std::string, long>& byte_counter,
   update_doc << "fragments" << byte_counter["fragments"];
   update_doc << "events" << byte_counter["events"];
   update_doc << "data_packets" << byte_counter["data_packets"];
-  update_doc << "processing_time_us" << proc_time_us;
+  update_doc << "processing_time_dp_us" << proc_time_dp_us;
+  update_doc << "processing_time_ev_us" << proc_time_ev_us;
+  update_doc << "processing_time_ch_us" << proc_time_ch_us;
   update_doc << "compression_time_us" << comp_time_us;
   update_doc << "buffer_xfers" << open_document;
   for (auto& p : buffer_counter) {

--- a/Options.hh
+++ b/Options.hh
@@ -86,7 +86,7 @@ public:
   std::vector<u_int16_t> GetThresholds(int board);
 
   void UpdateDAC(std::map<int, std::map<std::string, std::vector<double>>>&);
-  void SaveBenchmarks(std::map<std::string, long>&, std::map<int, long>&, double, double);
+  void SaveBenchmarks(std::map<std::string, long>&, std::map<int, long>&, double, double, double, double);
 private:
   mongocxx::client fClient;
   bsoncxx::document::view bson_options;

--- a/StraxInserter.cc
+++ b/StraxInserter.cc
@@ -392,7 +392,7 @@ void StraxInserter::ParseDocuments(data_packet* dp){
 int StraxInserter::AddFragmentToBuffer(std::string& fragment, int64_t timestamp) {
   // Get the CHUNK and decide if this event also goes into a PRE/POST file
   int chunk_id = timestamp/fFullChunkLength;
-  bool nextpre = (chunk_id+1)* fFullChunkLength - timestamp < fChunkOverlap;
+  bool nextpre = (chunk_id+1)* fFullChunkLength - timestamp <= fChunkOverlap;
   // Minor mess to maintain the same width of file names and do the pre/post stuff
   // If not in pre/post
   std::string chunk_index = std::to_string(chunk_id);

--- a/StraxInserter.cc
+++ b/StraxInserter.cc
@@ -10,8 +10,12 @@
 #include <numeric>
 #include <sstream>
 #include <list>
+#include <bitset>
+#include <iomanip>
 
 namespace fs=std::experimental::filesystem;
+using namespace std::chrono;
+const int event_header_words = 4, max_channels = 16;
 
 StraxInserter::StraxInserter(){
   fOptions = NULL;
@@ -38,8 +42,11 @@ StraxInserter::StraxInserter(){
 StraxInserter::~StraxInserter(){
   fActive = false;
   int counter_short = 0, counter_long = 0;
-  fLog->Entry(MongoLog::Local, "Thread %lx waiting to stop, has %i events left",
-      fThreadId, fBufferLength.load());
+  if (fBufferLength.load() > 0)
+    fLog->Entry(MongoLog::Local, "Thread %lx waiting to stop, has %i events left",
+        fThreadId, fBufferLength.load());
+  else
+    fLog->Entry(MongoLog::Local, "Thread %lx stopping", fThreadId);
   int events_start = fBufferLength.load();
   do{
     events_start = fBufferLength.load();
@@ -68,7 +75,7 @@ StraxInserter::~StraxInserter(){
     {"events", fEventsProcessed},
     {"data_packets", total_dps}};
   fOptions->SaveBenchmarks(counters, fBufferCounter,
-      fProcTime.count(), fCompTime.count());
+      fProcTimeDP.count(), fProcTimeEv.count(), fProcTimeCh.count(), fCompTime.count());
 }
 
 int StraxInserter::Initialize(Options *options, MongoLog *log, DAQController *dataSource,
@@ -88,11 +95,11 @@ int StraxInserter::Initialize(Options *options, MongoLog *log, DAQController *da
   fLog = log;
   fErrorBit = false;
 
-  fProcTime = std::chrono::microseconds(0);
-  fCompTime = std::chrono::microseconds(0);
+  fProcTimeDP = fProcTimeEv = fProcTimeCh = fCompTime = microseconds(0);
+  fBufferNumChunks = fOptions->GetInt("strax_buffer_num_chunks", 2);
 
   std::string output_path = fOptions->GetString("strax_output_path", "./");
-  try{    
+  try{
     fs::path op(output_path);
     op /= run_name;
     fOutputPath = op;
@@ -102,8 +109,6 @@ int StraxInserter::Initialize(Options *options, MongoLog *log, DAQController *da
     fLog->Entry(MongoLog::Error, "StraxInserter::Initialize tried to create output directory but failed. Check that you have permission to write here.");
     return -1;
   }
-  //fLog->Entry(MongoLog::Local, "Strax output initialized with %li ns chunks and %li ns overlap time",
-  //  fChunkLength, fChunkOverlap);
 
   return 0;
 }
@@ -146,258 +151,189 @@ void StraxInserter::GenerateArtificialDeadtime(int64_t timestamp, int16_t bid) {
   AddFragmentToBuffer(fragment, timestamp);
 }
 
-void StraxInserter::ParseDocuments(data_packet* dp){
+void StraxInserter::ProcessDatapacket(data_packet* dp){
 
-  using namespace std::chrono;
-  system_clock::time_point proc_start, proc_end;
+  system_clock::time_point proc_start, proc_end, ev_start, ev_end;
 
   // Take a buffer and break it up into one document per channel
-  unsigned int max_channels = 16; // hardcoded to accomodate V1730
 
-  // Unpack the things from the data packet
-  std::vector<u_int32_t> clock_counters(max_channels, dp->clock_counter);
-  std::vector<u_int32_t> last_times_seen(max_channels, 0xFFFFFFFF);
-
-  u_int32_t size = dp->size;
   u_int32_t *buff = dp->buff;
-  int smallest_latest_index_seen = -1;
-  const int event_header_words = 4;
-
   u_int32_t idx = 0;
-  std::map<std::string, int> fmt = fFmt[dp->bid];
-  std::map<int, int> data_per_chan;
-  unsigned total_words = size/sizeof(u_int32_t);
+  unsigned total_words = dp->size/sizeof(u_int32_t);
   proc_start = system_clock::now();
-  while(idx < total_words && buff[idx] != 0xFFFFFFFF){
-    
+  while(idx < total_words){
+
     if(buff[idx]>>28 == 0xA){ // 0xA indicates header at those bits
-
-      // Get data from main header
-      u_int32_t words_in_event = std::min(buff[idx]&0xFFFFFFF, total_words-idx);
-      u_int32_t channel_mask = (buff[idx+1]&0xFF);
-
-      if (words_in_event < (buff[idx]&0xFFFFFFF)) {
-        fLog->Entry(MongoLog::Local, "Board %i garbled event header at idx %i: %u/%u (%i)",
-            dp->bid, idx, buff[idx]&0xFFFFFFF, total_words-idx, dp->vBLT.size());
-      }
-
-      if (fmt["channel_mask_msb_idx"] != -1) {
-	channel_mask = ( ((buff[idx+2]>>24)&0xFF)<<8 ) | (buff[idx+1]&0xFF);
-      }
-      
-      // Exercise for the reader: if you're modifying for V1730 add in the rest of the bits here!
-      u_int32_t channels_in_event = __builtin_popcount(channel_mask);
-      bool board_fail = buff[idx+1]&0x4000000; // & (buff[idx+1]>>27)
-      u_int32_t event_time = buff[idx+3]&0xFFFFFFFF;
-      fEventsProcessed++;
-
-      if(board_fail){
-        const std::lock_guard<std::mutex> lg(fFC_mutex);
-        // would generate deadtime here but no timestamp
-        fDataSource->CheckError(dp->bid);
-	fFailCounter[dp->bid]++;
-        idx += event_header_words;
-        continue;
-      }
-      unsigned event_start_idx = idx;
-      idx += event_header_words; // skip header
-
-      for(unsigned int channel=0; channel<max_channels; channel++){
-	if(!((channel_mask>>channel)&1))
-	  continue;
-
-	// These defaults are valid for 'default' firmware where all channels same size
-	u_int32_t channel_words = (words_in_event-event_header_words) / channels_in_event;
-	u_int32_t channel_time = event_time;
-	u_int32_t channel_timeMSB = 0;
-	u_int16_t baseline_ch = 0;
-        bool whoops = false;
-
-	// Presence of a channel header indicates non-default firmware (DPP-DAW) so override
-	if(fmt["channel_header_words"] > 0){
-	  channel_words = std::min(buff[idx]&0x7FFFFF, words_in_event - (idx - event_start_idx));
-          if (channel_words < (buff[idx]&0x7FFFFF)) {
-            fLog->Entry(MongoLog::Local, "Board %i ch %i garbled header at idx %i: %x/%x",
-                  dp->bid, channel, idx, buff[idx]&0x7FFFFF, words_in_event);
-            idx += fmt["channel_header_words"];
-            break;
-          }
-          if (channel_words <= fmt["channel_header_words"]) {
-            fLog->Entry(MongoLog::Local, "Board %i ch %i empty (%i/%i)",
-                dp->bid, channel, channel_words, fmt["channel_header_words"]);
-            idx += (fmt["channel_header_words"]-channel_words);
-            continue;
-          }
-          channel_words -= fmt["channel_header_words"];
-	  channel_time = buff[idx+1]&0xFFFFFFFF;
-
-	  if (fmt["channel_time_msb_idx"] == 2) {
-	    channel_timeMSB = buff[idx+2]&0xFFFF;
-	    baseline_ch = (buff[idx+2]>>16)&0x3FFF;
-	  }
-	  
-	  idx += fmt["channel_header_words"];
-
-	  // V1724 only. 1730 has a **26-day** clock counter. 
-	  if(fmt["channel_header_words"] <= 2){    
-	    // OK. Here's the logic for the clock reset, and I realize this is the
-	    // second place in the code where such weird logic is needed but that's it
-	    // First, on the first instance of a channel we gotta check if
-	    // the channel clock rolled over BEFORE this clock and adjust the counter
-	    
-	    if(channel_time > 15e8 && dp->header_time<5e8 &&
-	       last_times_seen[channel] == 0xFFFFFFFF && clock_counters[channel]!=0){
-	      clock_counters[channel]--;
-	    }
-	    // Now check the opposite
-	    else if(channel_time <5e8 && dp->header_time > 15e8 &&
-		    last_times_seen[channel] == 0xFFFFFFFF){
-	      clock_counters[channel]++;
-	    }
-	    
-	    // Now check if this time < last time (indicates rollover)
-	    if(channel_time < last_times_seen[channel] &&
-	       last_times_seen[channel]!=0xFFFFFFFF)
-	      clock_counters[channel]++;
-
-	    last_times_seen[channel] = channel_time;
-	    
-	  }
-	} // channel_header_words > 0
-
-        // let's sanity-check the data first to make sure we didn't get CAENed
-        for (unsigned w = 0; w < channel_words; w++) {
-          if ((idx+w >= total_words) || (buff[idx+w]>>28) == 0xA) {
-            fLog->Entry(MongoLog::Local, "Board %i has CAEN'd itself at idx %x",
-                dp->bid, idx+w);
-            whoops = true;
-            break;
-          }
-        }
-        if (idx - event_start_idx >= words_in_event) {
-          fLog->Entry(MongoLog::Local, "Board %i CAEN'd itself at idx %x",
-              dp->bid, idx);
-          whoops = true;
-        }
-
-	// Exercise for reader. This is for our 30-bit trigger clock. If yours was, say,
-	// 48 bits this line would be different
-	int iBitShift = 31;
-	int64_t Time64;
-
-	 if (fmt["channel_time_msb_idx"] == 2) { 
-	   Time64 = fmt["ns_per_clk"]*( ( (unsigned long)channel_timeMSB<<(int)32) + channel_time); 
-	 } else {
-	   Time64 = fmt["ns_per_clk"]*(((unsigned long)clock_counters[channel] <<
-					      iBitShift) + channel_time); // in ns
-	}
-
-        if (whoops) { // some data got lost somewhere
-          GenerateArtificialDeadtime(Time64, dp->bid);
-          break; // loop over channels
-        }
-
-	// We're now at the first sample of the channel's waveform. This
-	// will be beautiful. First we reinterpret the channel as 16
-	// bit because we want to allow also odd numbers of samples
-	// as FragmentLength
-	u_int16_t *payload = reinterpret_cast<u_int16_t*>(buff);
-	u_int32_t samples_in_pulse = channel_words<<1;
-	u_int32_t index_in_pulse = 0;
-	u_int32_t offset = idx<<1;
-	u_int16_t fragment_index = 0;
-	u_int16_t sw = fmt["ns_per_sample"];
-        int fragment_samples = fFragmentBytes>>1;
-	int16_t cl = fOptions->GetChannel(dp->bid, channel);
-        data_per_chan[cl] += samples_in_pulse<<1;
-	// Failing to discern which channel we're getting data from seems serious enough to throw
-	if(cl==-1)
-	  throw std::runtime_error("Failed to parse channel map. I'm gonna just kms now.");
-          
-	
-	while(index_in_pulse < samples_in_pulse){
-	  std::string fragment;
-	  
-	  // How long is this fragment?
-	  u_int32_t max_sample = index_in_pulse + fragment_samples;
-	  u_int32_t samples_this_fragment = fragment_samples;
-	  if((unsigned int)(fragment_samples + (fragment_index*fragment_samples)) >
-	     samples_in_pulse){
-	    max_sample = index_in_pulse + (samples_in_pulse -
-					    (fragment_index*fragment_samples));
-	    samples_this_fragment = max_sample-index_in_pulse;
-	  }
-          fFragmentsProcessed++;
-
-	  u_int64_t time_this_fragment = Time64 + fragment_samples*sw*fragment_index;
-	  char *pulseTime = reinterpret_cast<char*> (&time_this_fragment);
-	  fragment.append(pulseTime, 8);
-
-	  char *fragmentlength = reinterpret_cast<char*> (&samples_this_fragment);
-	  fragment.append(fragmentlength, 4);
-
-	  char *sampleWidth = reinterpret_cast<char*> (&sw);
-	  fragment.append(sampleWidth, 2);
-
-	  char *channelLoc = reinterpret_cast<char*> (&cl);
-	  fragment.append(channelLoc, 2);
-
-	  char *samplesinpulse = reinterpret_cast<char*> (&samples_in_pulse);
-	  fragment.append(samplesinpulse, 4);
-
-	  char *fragmentindex = reinterpret_cast<char*> (&fragment_index);
-	  fragment.append(fragmentindex, 2);
-
-          char* bl = reinterpret_cast<char*>(&baseline_ch);
-          fragment.append(bl, 2);
-
-	  // Copy the raw buffer
-	  const char *data_loc = reinterpret_cast<const char*>(&(payload[offset+index_in_pulse]));
-	  fragment.append(data_loc, samples_this_fragment*2);
-          uint8_t zero_filler = 0;
-          char *zero = reinterpret_cast<char*> (&zero_filler);
-	  while((int)fragment.size()<fFragmentBytes+fStraxHeaderSize)
-	    fragment.append(zero, 1); // int(0) != int("0")
-
-          int chunk_id = AddFragmentToBuffer(fragment, time_this_fragment);
-
-	  // Check if this is the smallest_latest_index_seen
-	  if(smallest_latest_index_seen == -1 || chunk_id < smallest_latest_index_seen)
-	    smallest_latest_index_seen = chunk_id;
-	
-	  fragment_index++;
-	  index_in_pulse = max_sample;
-          if (fForceQuit == true) break;
-	} // while in pulse
-	idx+=channel_words;
-        if (fForceQuit == true) break;
-      } // channel loop
-      if (fForceQuit == true) break;
-    } // if header
-    else
+      ev_start = system_clock::now();
+      idx += ProcessEvent(buff+idx, total_words-idx, dp->clock_counter, dp->header_time, dp->bid);
+      ev_end = system_clock::now();
+      fProcTimeEv += duration_cast<microseconds>(ev_end - ev_start);
+    } else
       idx++;
+    if (fForceQuit) break;
   }
-  fDPC_mutex.lock();
-  for (auto& p : data_per_chan) fDataPerChan[p.first] += p.second;
-  fDPC_mutex.unlock();
   proc_end = system_clock::now();
-  if(smallest_latest_index_seen != -1)
-    WriteOutFiles(smallest_latest_index_seen);
-
+  fProcTimeDP += duration_cast<microseconds>(proc_end - proc_start);
   fBytesProcessed += dp->size;
-  fProcTime += duration_cast<microseconds>(proc_end - proc_start);
   delete dp;
 }
 
-int StraxInserter::AddFragmentToBuffer(std::string& fragment, int64_t timestamp) {
+uint32_t StraxInserter::ProcessEvent(uint32_t* buff, unsigned total_words, long clock_counter,
+    uint32_t header_time, int bid) {
+  // buff = start of event, total_words = valid words remaining in total buffer
+
+  system_clock::time_point proc_start, proc_end;
+  std::map<std::string, int> fmt = fFmt[bid];
+
+  u_int32_t words_in_event = std::min(buff[0]&0xFFFFFFF, total_words);
+  if (words_in_event < (buff[0]&0xFFFFFFF)) {
+    fLog->Entry(MongoLog::Local, "Board %i garbled event header: %u/%u",
+        bid, buff[0]&0xFFFFFFF, total_words);
+  }
+
+  u_int32_t channel_mask = (buff[1]&0xFF);
+  if (fmt["channel_mask_msb_idx"] != -1) channel_mask |= ( ((buff[2]>>24)&0xFF)<<8);
+
+  u_int32_t event_time = buff[3]&0x7FFFFFFF;
+  fEventsProcessed++;
+
+  if(buff[1]&0x4000000){ // board fail
+    const std::lock_guard<std::mutex> lg(fFC_mutex);
+    GenerateArtificialDeadtime(((clock_counter<<31) + header_time)*fmt["ns_per_clock"], bid);
+    fDataSource->CheckError(bid);
+    fFailCounter[bid]++;
+    return event_header_words;
+  }
+
+  unsigned idx = event_header_words;
+  int ret;
+
+  for(unsigned ch=0; ch<max_channels; ch++){
+    if (channel_mask & (1<<ch)) {
+      proc_start = system_clock::now();
+      ret = ProcessChannel(buff+idx, words_in_event, bid, ch, header_time, event_time,
+        clock_counter, channel_mask);
+      proc_end = system_clock::now();
+      fProcTimeCh += duration_cast<microseconds>(proc_end - proc_start);
+      if (ret == -1)
+        break;
+      idx += ret;
+    }
+  }
+  return idx;
+}
+
+int StraxInserter::ProcessChannel(uint32_t* buff, unsigned words_in_event, int bid, int channel,
+    uint32_t header_time, uint32_t event_time, long clock_counter, int channel_mask) {
+  // buff points to the first word of the channel's data
+
+  // These defaults are valid for 'default' firmware where all channels are the same size
+  int channels_in_event = std::bitset<max_channels>(channel_mask).count();
+  u_int32_t channel_words = (words_in_event-event_header_words) / channels_in_event;
+  long channel_time = (clock_counter<<31) + event_time;
+  long channel_timeMSB = 0;
+  u_int16_t baseline_ch = 0;
+  std::map<std::string, int> fmt = fFmt[bid];
+
+  // Presence of a channel header indicates non-default firmware (DPP-DAW) so override
+  if(fmt["channel_header_words"] > 0){
+    channel_words = std::min(buff[0]&0x7FFFFF, words_in_event);
+    if (channel_words < (buff[0]&0x7FFFFF)) {
+      fLog->Entry(MongoLog::Local, "Board %i ch %i garbled header: %x/%x",
+                  bid, channel, buff[0]&0x7FFFFF, words_in_event);
+      return -1;
+    }
+    if ((int)channel_words <= fmt["channel_header_words"]) {
+      fLog->Entry(MongoLog::Local, "Board %i ch %i empty (%i/%i)",
+            bid, channel, channel_words, fmt["channel_header_words"]);
+      return -1;
+    }
+    channel_time = buff[1]&0x7FFFFFFF;
+
+    if (fmt["channel_time_msb_idx"] == 2) {
+      channel_timeMSB = long(buff[2]&0xFFFF)<<32;
+      baseline_ch = (buff[2]>>16)&0x3FFF;
+    }
+
+    if(fmt["channel_header_words"] <= 2){
+      // More clock rollover logic here, because channels are independent
+      // and we process multithreaded. We leverage the fact that readout windows are short
+      // and polled frequently compared to the clock rollover timescale, so there will
+      // never be a "large" difference in realtime between timestamps in a data_packet
+
+      // first, has the main counter rolled but this channel hasn't?
+      if(channel_time>15e8 && header_time<5e8 && clock_counter!=0){
+        clock_counter--;
+      }
+      // Now check the opposite
+      else if(channel_time<5e8 && header_time>15e8){
+        clock_counter++;
+      }
+      channel_timeMSB = clock_counter<<31;
+    }
+  } // channel_header_words > 0
+
+  int64_t Time64 = fmt["ns_per_clk"]*(channel_timeMSB + channel_time); // in ns
+
+  // let's sanity-check the data first to make sure we didn't get CAENed
+  for (unsigned w = fmt["channel_header_words"]; w < channel_words; w++) {
+    if ((buff[w]>>28) == 0xA) {
+      fLog->Entry(MongoLog::Local, "Board %i has CAEN'd itself", bid);
+      GenerateArtificialDeadtime(Time64, bid);
+      return -1;
+    }
+  }
+
+  u_int16_t *payload = reinterpret_cast<u_int16_t*>(buff+fmt["channel_header_words"]);
+  u_int32_t samples_in_pulse = (channel_words-fmt["channel_header_words"])<<1;
+  u_int16_t sw = fmt["ns_per_sample"];
+  int fragment_samples = fFragmentBytes>>1;
+  int16_t cl = fOptions->GetChannel(bid, channel);
+  // Failing to discern which channel we're getting data from seems serious enough to throw
+  if(cl==-1)
+    throw std::runtime_error("Failed to parse channel map. I'm gonna just kms now.");
+
+  int num_frags = samples_in_pulse/fragment_samples + (samples_in_pulse % fragment_samples ? 1 : 0);
+  for (uint16_t frag_i = 0; frag_i < num_frags; frag_i++) {
+    std::string fragment;
+
+    // How long is this fragment?
+    u_int32_t samples_this_fragment = fragment_samples;
+    if (frag_i == num_frags-1)
+      samples_this_fragment = samples_in_pulse - frag_i*fragment_samples;
+    fFragmentsProcessed++;
+
+    u_int64_t time_this_fragment = Time64 + fragment_samples*sw*frag_i;
+    fragment.append((char*)&time_this_fragment, sizeof(time_this_fragment));
+    fragment.append((char*)&samples_this_fragment, sizeof(samples_this_fragment));
+    fragment.append((char*)&sw, sizeof(sw));
+    fragment.append((char*)&cl, sizeof(cl));
+    fragment.append((char*)&samples_in_pulse, sizeof(samples_in_pulse));
+    fragment.append((char*)&frag_i, sizeof(frag_i));
+    fragment.append((char*)&baseline_ch, sizeof(baseline_ch));
+
+    // Copy the raw buffer
+    fragment.append((char*)(payload + frag_i*fragment_samples), samples_this_fragment*2);
+    uint16_t zero_filler = 0;
+    while((int)fragment.size()<fFragmentBytes+fStraxHeaderSize)
+      fragment.append((char*)&zero_filler, 2);
+
+    AddFragmentToBuffer(fragment, time_this_fragment);
+  } // loop over frag_i
+  {
+    const std::lock_guard<std::mutex> lg(fDPC_mutex);
+    fDataPerChan[cl] += samples_in_pulse<<1;
+  }
+  return channel_words;
+}
+
+void StraxInserter::AddFragmentToBuffer(std::string& fragment, int64_t timestamp) {
   // Get the CHUNK and decide if this event also goes into a PRE/POST file
   int chunk_id = timestamp/fFullChunkLength;
   bool nextpre = (chunk_id+1)* fFullChunkLength - timestamp <= fChunkOverlap;
   // Minor mess to maintain the same width of file names and do the pre/post stuff
   // If not in pre/post
-  std::string chunk_index = std::to_string(chunk_id);
-  while(chunk_index.size() < fChunkNameLength)
-    chunk_index.insert(0, "0");
+  std::string chunk_index = GetStringFormat(chunk_id);
 
   fFragmentSize += fragment.size();
 
@@ -406,30 +342,30 @@ int StraxInserter::AddFragmentToBuffer(std::string& fragment, int64_t timestamp)
       fFragments[chunk_index] = new std::string();
     }
     fFragments[chunk_index]->append(fragment);
+    fTimeLastSeen[chunk_index] = system_clock::now();
   } else {
-    std::string nextchunk_index = std::to_string(chunk_id+1);
-    while(nextchunk_index.size() < fChunkNameLength)
-      nextchunk_index.insert(0, "0");
+    std::string nextchunk_index = GetStringFormat(chunk_id+1);
 
     if(fFragments.count(nextchunk_index+"_pre") == 0){
       fFragments[nextchunk_index+"_pre"] = new std::string();
     }
     fFragments[nextchunk_index+"_pre"]->append(fragment);
+    fTimeLastSeen[nextchunk_index+"_pre"] = system_clock::now();
 
     if(fFragments.count(chunk_index+"_post") == 0){
       fFragments[chunk_index+"_post"] = new std::string();
     }
     fFragments[chunk_index+"_post"]->append(fragment);
+    fTimeLastSeen[chunk_index+"_post"] = system_clock::now();
   }
-  return chunk_id;
 }
-
 
 int StraxInserter::ReadAndInsertData(){
   fThreadId = std::this_thread::get_id();
   fActive = fRunning = true;
   fBufferLength = 0;
   std::chrono::microseconds sleep_time(10);
+  int counter = 0;
   if (fOptions->GetString("buffer_type", "dual") == "dual") {
     while(fActive == true){
       std::list<data_packet*> b;
@@ -437,16 +373,23 @@ int StraxInserter::ReadAndInsertData(){
         fBufferLength = b.size();
         fBufferCounter[int(b.size())]++;
         for (auto& dp_ : b) {
-          ParseDocuments(dp_);
+          ProcessDatapacket(dp_);
           fBufferLength--;
           dp_ = nullptr;
           if (fForceQuit) break;
         }
         if (fForceQuit) for (auto& dp_ : b) if (dp_ != nullptr) delete dp_;
         b.clear();
+        WriteOutFiles();
       } else {
         std::this_thread::sleep_for(sleep_time);
       }
+      /*if (((++counter) % 1000 == 0) && (fFragments.size() > 0)) {
+        std::stringstream msg;
+        msg << "Current chunks " << std::hex<<fThreadId<<std::dec;
+        for (auto& it : fFragments) msg << ' ' << it.first;
+        fLog->Entry(MongoLog::Local, msg.str());
+      }*/
     }
   } else {
     data_packet* dp;
@@ -454,15 +397,16 @@ int StraxInserter::ReadAndInsertData(){
       if (fDataSource->GetData(dp)) {
         fBufferLength = 1;
         fBufferCounter[1]++;
-        ParseDocuments(dp);
+        ProcessDatapacket(dp);
         fBufferLength = 0;
+        WriteOutFiles();
       } else {
         std::this_thread::sleep_for(sleep_time);
       }
     }
   }
   if (fBytesProcessed > 0)
-    WriteOutFiles(1000000, true);
+    WriteOutFiles(true);
   fRunning = false;
   return 0;
 }
@@ -475,19 +419,20 @@ static const LZ4F_preferences_t kPrefs = {
     { 0, 0, 0 },  /* reserved, must be set to 0 */
 };
 
-void StraxInserter::WriteOutFiles(int smallest_index_seen, bool end){
-  // Write the contents of fFragments to blosc-compressed files
-  using namespace std::chrono;
+void StraxInserter::WriteOutFiles(bool end){
+  // Write the contents of fFragments to compressed files
   system_clock::time_point comp_start, comp_end;
   std::vector<std::string> idx_to_clear;
+  int max_chunk = -1;
+  for (auto& iter : fFragments) max_chunk = std::max(max_chunk, std::stoi(iter.first));
+  int write_lte = max_chunk - fBufferNumChunks;
   for (auto& iter : fFragments) {
     if (iter.first == "")
-        break; // not sure why, but this sometimes happens during bad shutdowns
+        continue; // not sure why, but this sometimes happens during bad shutdowns
     std::string chunk_index = iter.first;
-    std::string idnr = chunk_index.substr(0, fChunkNameLength);
-    int idnrint = std::stoi(idnr);
-    if(!(idnrint < smallest_index_seen-1 || end))
-      continue;
+    if (std::stoi(chunk_index) > write_lte && !end) continue;
+    //fLog->Entry(MongoLog::Local, "Thread %lx max %i current %i buffer %i write_lte %i",
+    //    fThreadId, max_chunk, std::stoi(chunk_index), fBufferNumChunks, write_lte);
 
     comp_start = system_clock::now();
     if(!fs::exists(GetDirectoryPath(chunk_index, true)))
@@ -520,8 +465,15 @@ void StraxInserter::WriteOutFiles(int smallest_index_seen, bool end){
 
     std::ofstream writefile(GetFilePath(chunk_index, true), std::ios::binary);
     writefile.write(out_buffer, wsize);
+//    fLog->Entry(MongoLog::Local, "Thread %lx wrote chunk %s", fThreadId, chunk_index.c_str());
     delete[] out_buffer;
     writefile.close();
+
+    // shenanigans or skulduggery?
+    if(fs::exists(GetFilePath(chunk_index, false))) {
+      fLog->Entry(MongoLog::Warning, "Chunk %s from thread %lx already exists? Data loss warning",
+          chunk_index.c_str(), fThreadId);
+    }
 
     // Move this chunk from *_TEMP to the same path without TEMP
     if(!fs::exists(GetDirectoryPath(chunk_index, false)))
@@ -530,8 +482,8 @@ void StraxInserter::WriteOutFiles(int smallest_index_seen, bool end){
 	       GetFilePath(chunk_index, false));
     comp_end = system_clock::now();
     fCompTime += duration_cast<microseconds>(comp_end-comp_start);
-    
-    CreateMissing(idnrint);
+
+    CreateMissing(std::stoi(iter.first));
   } // End for through fragments
   // clear now because c++ sometimes overruns its buffers
   for (auto s : idx_to_clear) {

--- a/StraxInserter.cc
+++ b/StraxInserter.cc
@@ -97,6 +97,7 @@ int StraxInserter::Initialize(Options *options, MongoLog *log, DAQController *da
 
   fProcTimeDP = fProcTimeEv = fProcTimeCh = fCompTime = microseconds(0);
   fBufferNumChunks = fOptions->GetInt("strax_buffer_num_chunks", 2);
+  fWarnIfChunkOlderThan = fOptions->GetInt("strax_chunk_phase_limit", 2);
 
   std::string output_path = fOptions->GetString("strax_output_path", "./");
   try{
@@ -346,7 +347,7 @@ void StraxInserter::AddFragmentToBuffer(std::string& fragment, int64_t timestamp
     const short* channel = (const short*)(fragment.data()+14);
     fLog->Entry(MongoLog::Warning,
         "Thread %lx got data from channel %i that's %i chunks behind the buffer, it might get lost",
-        fThreadID, *channel, min_chunk - chunk_id);
+        fThreadId, *channel, min_chunk - chunk_id);
   } else if (chunk_id - max_chunk > 2) {
     fLog->Entry(MongoLog::Message, "Thread %lx skipped %i chunk(s)"
         fThreadId, chunk_id - max_chunk - 1);

--- a/StraxInserter.cc
+++ b/StraxInserter.cc
@@ -349,7 +349,7 @@ void StraxInserter::AddFragmentToBuffer(std::string& fragment, int64_t timestamp
         "Thread %lx got data from channel %i that's %i chunks behind the buffer, it might get lost",
         fThreadId, *channel, min_chunk - chunk_id);
   } else if (chunk_id - max_chunk > 2) {
-    fLog->Entry(MongoLog::Message, "Thread %lx skipped %i chunk(s)"
+    fLog->Entry(MongoLog::Message, "Thread %lx skipped %i chunk(s)",
         fThreadId, chunk_id - max_chunk - 1);
   }
 

--- a/StraxInserter.cc
+++ b/StraxInserter.cc
@@ -365,7 +365,6 @@ int StraxInserter::ReadAndInsertData(){
   fActive = fRunning = true;
   fBufferLength = 0;
   std::chrono::microseconds sleep_time(10);
-  int counter = 0;
   if (fOptions->GetString("buffer_type", "dual") == "dual") {
     while(fActive == true){
       std::list<data_packet*> b;
@@ -384,12 +383,6 @@ int StraxInserter::ReadAndInsertData(){
       } else {
         std::this_thread::sleep_for(sleep_time);
       }
-      /*if (((++counter) % 1000 == 0) && (fFragments.size() > 0)) {
-        std::stringstream msg;
-        msg << "Current chunks " << std::hex<<fThreadId<<std::dec;
-        for (auto& it : fFragments) msg << ' ' << it.first;
-        fLog->Entry(MongoLog::Local, msg.str());
-      }*/
     }
   } else {
     data_packet* dp;

--- a/StraxInserter.hh
+++ b/StraxInserter.hh
@@ -58,7 +58,7 @@ private:
   uint32_t ProcessEvent(uint32_t*, unsigned, long, uint32_t, int);
   int ProcessChannel(uint32_t*, unsigned, int, int, uint32_t, uint32_t, long, int);
   void WriteOutFiles(bool end=false);
-  void GenerateArtificialDeadtime(int64_t, int16_t);
+  void GenerateArtificialDeadtime(int64_t, int16_t, uint32_t, int);
   void AddFragmentToBuffer(std::string&&, int64_t, uint32_t, int);
 
   std::experimental::filesystem::path GetFilePath(std::string id, bool temp);

--- a/StraxInserter.hh
+++ b/StraxInserter.hh
@@ -54,10 +54,12 @@ public:
   int GetBufferLength() {return fBufferLength.load();}
   
 private:
-  void ParseDocuments(data_packet *dp);
-  void WriteOutFiles(int smallest_index_seen, bool end=false);
+  void ProcessDatapacket(data_packet *dp);
+  uint32_t ProcessEvent(uint32_t*, unsigned, long, uint32_t, int);
+  int ProcessChannel(uint32_t*, unsigned, int, int, uint32_t, uint32_t, long, int);
+  void WriteOutFiles(bool end=false);
   void GenerateArtificialDeadtime(int64_t timestamp, int16_t bid);
-  int AddFragmentToBuffer(std::string& fragment, int64_t timestamp);
+  void AddFragmentToBuffer(std::string& fragment, int64_t timestamp);
 
   std::experimental::filesystem::path GetFilePath(std::string id, bool temp);
   std::experimental::filesystem::path GetDirectoryPath(std::string id, bool temp);
@@ -69,6 +71,7 @@ private:
   int64_t fChunkOverlap; // ns
   int fFragmentBytes; // This is in BYTES
   int fStraxHeaderSize; // in BYTES too
+  int fBufferNumChunks;
   unsigned fChunkNameLength;
   int64_t fFullChunkLength;
   std::string fOutputPath, fHostname;
@@ -87,12 +90,12 @@ private:
   std::mutex fDPC_mutex;
   std::map<int, long> fBufferCounter;
   std::atomic_int fBufferLength;
+  std::map<std::string, std::chrono::system_clock::time_point> fTimeLastSeen;
   long fBytesProcessed;
   long fFragmentsProcessed;
   long fEventsProcessed;
 
-  std::chrono::microseconds fProcTime;
-  std::chrono::microseconds fCompTime;
+  std::chrono::microseconds fProcTimeDP, fProcTimeEv, fProcTimeCh, fCompTime;
   std::thread::id fThreadId;
 };
 

--- a/StraxInserter.hh
+++ b/StraxInserter.hh
@@ -58,8 +58,8 @@ private:
   uint32_t ProcessEvent(uint32_t*, unsigned, long, uint32_t, int);
   int ProcessChannel(uint32_t*, unsigned, int, int, uint32_t, uint32_t, long, int);
   void WriteOutFiles(bool end=false);
-  void GenerateArtificialDeadtime(int64_t timestamp, int16_t bid);
-  void AddFragmentToBuffer(std::string& fragment, int64_t timestamp);
+  void GenerateArtificialDeadtime(int64_t, int16_t);
+  void AddFragmentToBuffer(std::string&&, int64_t, uint32_t, int);
 
   std::experimental::filesystem::path GetFilePath(std::string id, bool temp);
   std::experimental::filesystem::path GetDirectoryPath(std::string id, bool temp);

--- a/StraxInserter.hh
+++ b/StraxInserter.hh
@@ -72,6 +72,7 @@ private:
   int fFragmentBytes; // This is in BYTES
   int fStraxHeaderSize; // in BYTES too
   int fBufferNumChunks;
+  int fWarnIfChunkOlderThan;
   unsigned fChunkNameLength;
   int64_t fFullChunkLength;
   std::string fOutputPath, fHostname;

--- a/V1724.cc
+++ b/V1724.cc
@@ -1,6 +1,5 @@
 #include "V1724.hh"
 #include <numeric>
-#include <array>
 #include <algorithm>
 #include <bitset>
 #include <cmath>
@@ -15,6 +14,7 @@
 #include <sstream>
 #include <list>
 #include <utility>
+#include <fstream>
 
 
 V1724::V1724(MongoLog  *log, Options *options){

--- a/ccontrol.cc
+++ b/ccontrol.cc
@@ -166,6 +166,6 @@ int main(int argc, char** argv){
   } // while run
   if (options != NULL) delete options;
   delete fHandler;
-  delete fLogger;
+  delete logger;
   return 0;
 }

--- a/ccontrol.cc
+++ b/ccontrol.cc
@@ -6,13 +6,23 @@
 #include <limits.h>
 #include <unistd.h>
 #include <chrono>
+#include <csignal>
+#include <atomic>
+
+std::atomic_bool b_run = true;
+
+void SignalHandler(int signum) {
+    std::cout << "Received signal "<<signum<<std::endl;
+    b_run = false;
+    return;
+}
 
 #include <mongocxx/instance.hpp>
 #include <bsoncxx/builder/stream/document.hpp>
 #include <bsoncxx/json.hpp>
 
 int main(int argc, char** argv){
-  
+
   mongocxx::instance instance{};
   // Parse arguments
   if(argc < 3){
@@ -57,10 +67,10 @@ int main(int argc, char** argv){
   Options *options = NULL;
   
   // Holds session data
-  CControl_Handler *fHandler = new CControl_Handler(logger, hostname);  
+  CControl_Handler *fHandler = new CControl_Handler(logger, hostname);
   using namespace std::chrono;
 
-  while(1){
+  while(b_run){
 
     auto order = bsoncxx::builder::stream::document{} <<
       "_id" << 1 <<bsoncxx::builder::stream::finalize;
@@ -153,7 +163,7 @@ int main(int argc, char** argv){
       std::cout<<"Couldn't update database, I'll keep doing my thing\n";
     }
     std::this_thread::sleep_for(seconds(1));
-  }
+  } // while run
   if (options != NULL) delete options;
   delete fHandler;
   delete fLogger;

--- a/ccontrol.cc
+++ b/ccontrol.cc
@@ -122,7 +122,7 @@ int main(int argc, char** argv){
 	 delete options;
 	 options = NULL;
        }
-       options = new Options(logger, mode, mongo_uri, dbname, override_json);
+       options = new Options(logger, mode, hostname, mongo_uri, dbname, override_json);
 	 
        // Initialise the V2178, V1495 and DDC10...etc.      
        if(fHandler->DeviceArm(run, options) != 0){

--- a/ccontrol.cc
+++ b/ccontrol.cc
@@ -153,6 +153,9 @@ int main(int argc, char** argv){
           if((fHandler->DeviceStop()) != 0){
             logger->Entry(MongoLog::Warning, "Failed to stop devices");
           }
+          auto start_time = system_clock::now();
+          logger->Entry(MongoLog::Local, "Ack to Stop took %i us",
+            duration_cast<microseconds>(start_time-ack_time).count());
         }
       } //end for
     } catch (const std::exception& e) {

--- a/ccontrol.cc
+++ b/ccontrol.cc
@@ -74,14 +74,19 @@ int main(int argc, char** argv){
     
     for (auto doc : cursor) {
       // Acknowledge the commands
-      control.update_one
-        (bsoncxx::builder::stream::document{} << "_id" << doc["_id"].get_oid() <<
-         bsoncxx::builder::stream::finalize,
-         bsoncxx::builder::stream::document{} << "$push" <<
-         bsoncxx::builder::stream::open_document << "acknowledged" << hostname <<
-         bsoncxx::builder::stream::close_document <<
-         bsoncxx::builder::stream::finalize
-         );
+      try {
+        control.update_one
+          (bsoncxx::builder::stream::document{} << "_id" << doc["_id"].get_oid() <<
+            bsoncxx::builder::stream::finalize,
+            bsoncxx::builder::stream::document{} << "$push" <<
+            bsoncxx::builder::stream::open_document << "acknowledged" << hostname <<
+            bsoncxx::builder::stream::close_document <<
+            bsoncxx::builder::stream::finalize
+            );
+      } catch (...) {
+        std::cout<<"Can't access db, I'll keep doing my thing\n";
+        continue;
+      }
       
       // Strip data from the supplied doc
       int run = -1;
@@ -145,7 +150,11 @@ int main(int argc, char** argv){
     } //end for  
  
     // Report back on what we are doing
-    status.insert_one(fHandler->GetStatusDoc(hostname));
+    try{
+      status.insert_one(fHandler->GetStatusDoc(hostname));
+    } catch(...) {
+      std::cout<<"Couldn't update database, I'll keep doing my thing\n";
+    }
    usleep(1000000);
   }
   return 0;

--- a/dispatcher/DAQController.py
+++ b/dispatcher/DAQController.py
@@ -229,7 +229,7 @@ class DAQController():
             host_list, cc = self.mongo.GetHostsForMode(run_mode)
             for c in cc:
                 host_list.append(c)
-	    self.log.debug('Sending ARM to %s' % detector)
+            self.log.debug('Sending ARM to %s' % detector)
             self.mongo.SendCommand("arm", host_list, self.goal_state[detector]['user'],
                                    detector, self.goal_state[detector]['mode'])
             self.arm_command_sent[detector] = datetime.datetime.utcnow()
@@ -255,7 +255,7 @@ class DAQController():
             run = self.mongo.InsertRunDoc(detector, self.goal_state)
             for c in cc:
                 host_list.append(c)
-	    self.log.debug('Sending START to %s' % detector)
+            self.log.debug('Sending START to %s' % detector)
             self.mongo.SendCommand("start", host_list, self.goal_state[detector]['user'],
                                    detector, self.goal_state[detector]['mode'])
             self.start_command_sent[detector] = datetime.datetime.utcnow()
@@ -281,7 +281,7 @@ class DAQController():
 
         # We do not need to check the 'stop_command_sent' because this function is
         # exclusively called through the CheckTimeouts wrapper
-	self.log.debug('Sending STOP to %s' % detector)
+        self.log.debug('Sending STOP to %s' % detector)
         self.mongo.SendCommand("stop", cc, self.goal_state[detector]['user'],
                                detector, self.goal_state[detector]['mode'])
         self.mongo.SendCommand("stop", readers, self.goal_state[detector]['user'],
@@ -324,7 +324,7 @@ class DAQController():
         # Case 2: we're not timing out at all, send the stop command
         if (detector not in self.stop_command_sent.keys() or self.stop_command_sent[detector] is None):
             sendstop = True
-	    self.log.debug('Stopping %s, Case 2' % detector)
+            self.log.debug('Stopping %s, Case 2' % detector)
             self.stop_command_sent[detector] = nowtime
             self.error_stop_count[detector] = 0
 
@@ -370,7 +370,7 @@ class DAQController():
                 sendstop = False
             elif self.error_stop_count[detector] < self.stop_retries:
                 sendstop = True
-		self.log.debug('Working on a stop timeout for %s' % detector)
+                self.log.debug('Working on a stop timeout for %s' % detector)
                 self.error_stop_count[detector] += 1
 
         if sendstop:

--- a/dispatcher/DAQController.py
+++ b/dispatcher/DAQController.py
@@ -261,6 +261,8 @@ class DAQController():
                 delay = 0
                 if command == 'start':
                     run = self.mongo.InsertRunDoc(detector, self.goal_state)
+                    if run == -1:  # runs db having a moment
+                        return
             else: # stop
                 readers, cc = self.mongo.GetConfiguredNodes(detector,
                     self.goal_state['tpc']['link_mv'], self.goal_state['tpc']['link_nv'])

--- a/dispatcher/DAQController.py
+++ b/dispatcher/DAQController.py
@@ -304,7 +304,7 @@ class DAQController():
 
         dt = (nowtime - self.last_command[command][detector]).total_seconds()
 
-        local_timeouts = self.timeouts
+        local_timeouts = dict(self.timeouts.items())
         local_timeouts['stop'] = self.timeouts['stop']*(self.error_stop_count[detector]+1)
 
         if dt < local_timeouts[command]:

--- a/dispatcher/DAQController.py
+++ b/dispatcher/DAQController.py
@@ -284,7 +284,6 @@ class DAQController():
                 command, detector, dt, self.timeouts[command]))
             #self.CheckTimeouts(detector=detector, command=command)
 
-
     def CheckTimeouts(self, detector, command = None):
         ''' 
         This one is invoked if we think we need to change states. Either a stop command needs

--- a/dispatcher/DAQController.py
+++ b/dispatcher/DAQController.py
@@ -265,17 +265,15 @@ class DAQController():
                 delay = 5
                 # TODO smart delay?
             self.log.debug('Sending %s to %s' % (command.upper(), detector))
-            if (self.mongo.SendCommand(command, cc, self.goal_state[detector]['user'],
-                    detector, self.goal_state[detector]['mode']) or 
-                self.mongo.SendCommand(command, readers, self.goal_state[detector]['user'],
-                    detector, self.goal_state[detector]['mode'], delay)):
+            if self.mongo.SendCommand(command, (cc, readers), self.goal_state[detector]['user'],
+                    detector, self.goal_state[detector]['mode'], delay):
                 # failed
                 return
             self.last_command[command][detector] = now
             if command == 'start' and self.mongo.InsertRunDoc(detector, self.goal_state):
                 # db having a moment
                 return
-            if command == 'stop' and self.mongo.SetStopTime(self.latest_status[detector]['number']):
+            if command == 'stop' and self.mongo.SetStopTime(self.latest_status[detector]['number'], detector):
                 # db having a moment
                 return
 

--- a/dispatcher/MongoConnect.py
+++ b/dispatcher/MongoConnect.py
@@ -1,4 +1,5 @@
 from pymongo import MongoClient
+from pymongo.errors import NotMasterError
 import datetime
 import os
 import json
@@ -147,7 +148,10 @@ class MongoConnect():
             }
             if 'number' in self.latest_status[detector].keys():
                 doc['number'] = self.latest_status[detector]['number']
-            self.collections['aggregate_status'].insert(doc)
+            try:
+                self.collections['aggregate_status'].insert(doc)
+            except NotMasterError:
+                self.log.error('RunsDB snafu')
 
     def AggregateStatus(self):
 
@@ -242,10 +246,14 @@ class MongoConnect():
         # Pull the wanted state per detector from the DB and return a dict
         retdoc = {}
         for detector in self.latest_status.keys():
-            command = self.collections['incoming_commands'].find_one(
-                {"detector": detector})
+            try:
+                command = self.collections['incoming_commands'].find_one(
+                    {"detector": detector})
+            except NotMasterError:
+                self.log.error('Database snafu')
+                return None
             if command is None:
-                print("Error! Wanted to find command for detector %s but it isn't there"%detector)
+                self.log.error("Wanted to find command for detector %s but it isn't there"%detector)
             retdoc[detector] = command
         self.latest_settings = retdoc
         return retdoc
@@ -278,7 +286,11 @@ class MongoConnect():
         '''
         if mode is None:
             return None
-        doc = self.collections["options"].find_one({"name": mode})
+        try:
+            doc = self.collections["options"].find_one({"name": mode})
+        except NotMasterError:
+            self.log.error('Database snafu')
+            return None
         fields_to_exclude = ['name', 'detector', 'description', 'user', '_id']
         try:
             newdoc = {**dict(doc)}
@@ -290,6 +302,8 @@ class MongoConnect():
                             del incdoc[field]
                     newdoc.update(incdoc)
             return newdoc
+        except NotMasterError:
+            self.log.error('Database snafu')
         except Exception as E:
             # LOG ERROR
             self.log.error("Got a %s exception in doc pulling: %s" % (type(E), E))
@@ -317,7 +331,11 @@ class MongoConnect():
         return hostlist, cc
 
     def GetNextRunNumber(self):
-        cursor = self.collections["run"].find().sort("number", -1).limit(1)
+        try:
+            cursor = self.collections["run"].find().sort("number", -1).limit(1)
+        except NotMasterError:
+            self.log.error('Database is having a moment')
+            return -1
         if cursor.count() == 0:
             self.log.info("wtf, first run?")
             return 0
@@ -328,8 +346,11 @@ class MongoConnect():
         Set's the 'end' field of the run doc to the current time if not done yet
         '''
         self.log.info("Updating run %i with end time"%number)
-        self.collections['run'].update_one({"number": int(number), "end": {"$exists": False}},
+        try:
+            self.collections['run'].update_one({"number": int(number), "end": {"$exists": False}},
                                           {"$set": {"end": datetime.datetime.utcnow()}})
+        except NotMasterError:
+            self.log.error("Database having a moment, hope this doesn't crash")
 
     def SendCommand(self, command, host_list, user, detector, mode="", delay=0):
         '''
@@ -360,12 +381,17 @@ class MongoConnect():
         '''
         nowtime = datetime.datetime.utcnow()
         afterlist = []
-        for command in self.outgoing_commands:
+        for i,command in enumerate(self.outgoing_commands):
             if command['createdAt'] <= nowtime:
-                self.collections['outgoing_commands'].insert(command)
+                try:
+                    self.collections['outgoing_commands'].insert(command)
+                except NotMasterError:
+                    self.log.error('Database snafu')
+                    afterlist = afterlist + self.outgoing_commands[i:]
+                    break
             else:
                 afterlist.append(command)
-        self.outgoing_commands = afterlist
+        self.outgoing_commands = sorted(afterlist, key=lambda x : x['createdAt'])
         return
 
     def LogError(self, reporter, message, priority, etype):
@@ -387,7 +413,11 @@ class MongoConnect():
         return
 
     def GetRunStart(self, number):
-        doc = self.collections['run'].find_one({"number": number}, {"start": 1})
+        try:
+            doc = self.collections['run'].find_one({"number": number}, {"start": 1})
+        except NotMasterError:
+            self.log.error('Database is having a moment')
+            return None
         if doc is not None:
             return doc['start']
         return None
@@ -436,5 +466,9 @@ class MongoConnect():
         # outside world to any degree of precision without invoking said GPS time
         run_doc['start'] = datetime.datetime.utcnow()
 
-        self.collections['run'].insert_one(run_doc)
+        try:
+            self.collections['run'].insert_one(run_doc)
+        except NotMasterError:
+            self.log.error('Database having a moment')
+            return -1
         return number

--- a/dispatcher/config.ini
+++ b/dispatcher/config.ini
@@ -14,10 +14,10 @@ ClientTimeout = 10
 
 # Database URIs. Please store DB password in the MONGO_PASSWORD
 # environment variable and runs DB password as RUNS_MONGO_PASSWORD
-ControlDatabaseURI = mongodb://daq:%%s@xenon1t-daq:27020/admin
+ControlDatabaseURI = mongodb://daq:%%s@xenon1t-daq:27017/admin
 ControlDatabaseName = daq
 RunsDatabaseURI = mongodb://daq:%%s@xenon1t-daq:27017/admin
-RunsDatabaseName = run
+RunsDatabaseName = xenonnt
 RunsDatabaseCollection = runs
 
 # Timeouts (seconds to wait until we assume it failed)

--- a/dispatcher/config.ini
+++ b/dispatcher/config.ini
@@ -10,7 +10,7 @@ ArmTimeout = 40
 
 # How long since a client's last check-in until we consider
 # it to be 'timing out'
-ClientTimeout = 30
+ClientTimeout = 10
 
 # Database URIs. Please store DB password in the MONGO_PASSWORD
 # environment variable and runs DB password as RUNS_MONGO_PASSWORD
@@ -19,11 +19,6 @@ ControlDatabaseName = daq
 RunsDatabaseURI = mongodb://daq:%%s@xenon1t-daq:27017/admin
 RunsDatabaseName = run
 RunsDatabaseCollection = runs
-
-# Chris stupid mongo
-#RunsDatabaseURI = mongodb://rucio:%%s@rundbcluster-shard-00-00-cfaei.gcp.mongodb.net:27017,rundbcluster-shard-00-01-cfaei.gcp.mongodb.net:27017,rundbcluster-shard-00-02-cfaei.gcp.mongodb.net:27017/test?ssl=true&replicaSet=RunDBCluster-shard-0&authSource=admin&retryWrites=true
-#RunsDatabaseName = xenon1t
-#RunsDatabaseCollection = runs
 
 # Timeouts (seconds to wait until we assume it failed)
 # Give Arm command some time in case baselines noisy
@@ -35,26 +30,28 @@ StopCommandTimeout = 30
 # Also retry stop/reset n times before throwing alarm this one is not in seconds
 # but is the number of times to retry (seconds_before_alarm = n*StopCommandTimeout)
 RetryReset = 3
+# Min time between Stop-Arm and Arm-Start commands
+TimeBetweenCommands = 6
 
 # Declare detector configuration here. Each detector's top level
 # key is its system-wide name identifier. Under the top-level
 # hosts are fields for the readers and crate controller.
 MasterDAQConfig = {
-		"tpc": {
-		       "controller": ["reader0_controller_0"],
-		       "readers": [
-		       		  "reader0_reader_0",
-				  "reader1_reader_0",
-				  "reader2_reader_0",
-                  "reader3_reader_0"
-				  ]
-			},
-		"muon_veto": {
-			     "controller": ["reader5_controller_0"],
-			     "readers": ["reader5_reader_0"]
-		},
-		"neutron_veto": {
-			"controller": [],
-			"readers":    []
-		}
-	}
+        "tpc": {
+            "controller": ["reader0_controller_0"],
+            "readers": [
+                "reader0_reader_0",
+                "reader1_reader_0",
+                "reader2_reader_0",
+                "reader3_reader_0"
+            ]
+        },
+        "muon_veto": {
+            "controller": ["reader5_controller_0"],
+            "readers": ["reader5_reader_0"]
+        },
+        "neutron_veto": {
+            "controller": [],
+            "readers":    []
+        }
+    }

--- a/dispatcher/config.ini
+++ b/dispatcher/config.ini
@@ -45,7 +45,8 @@ MasterDAQConfig = {
 		       "readers": [
 		       		  "reader0_reader_0",
 				  "reader1_reader_0",
-				  "reader2_reader_0"
+				  "reader2_reader_0",
+                  "reader3_reader_0"
 				  ]
 			},
 		"muon_veto": {

--- a/dispatcher/dispatcher.py
+++ b/dispatcher/dispatcher.py
@@ -6,7 +6,7 @@ import logging
 import logging.handlers
 
 from MongoConnect import MongoConnect
-from DAQController import DAQController
+from DAQController import DAQController, STATUS
 
 # Parse command line
 parser = argparse.ArgumentParser(description='Manage the DAQ')
@@ -30,8 +30,6 @@ logger.setLevel(getattr(logging, args.log))
 print("Config arm timeout: %i"%int(config["DEFAULT"]["ArmCommandTimeout"]))
 # Declare database object
 MongoConnector = MongoConnect(config, logger)
-state_codes = ["IDLE", "ARMING", "ARMED", "RUNNING", "ERROR", "TIMEOUT", "UNDECIDED"]
-pending_commands = []
 
 # Declare a 'brain' object. This will cache info about the DAQ state in order to
 # solve the want/have decisions. The deciding functions also go here. It needs a
@@ -56,9 +54,7 @@ while(1):
 
     # Print an update
     for detector in latest_status.keys():
-        if goal_state[detector]['active'] == 'false':
-            logger.debug("Detector %s INACTIVE"%detector)
-        else:
-            logger.debug("Detector %s should be ACTIVE and is %s"%(
-                detector, state_codes[latest_status[detector]['status']]))
+        logger.debug("Detector %s should be %sACTIVE and is %s"%(
+                detector, '' if goal_state[detector]['active'] == 'true' else 'IN',
+                latest_status[detector]['status'].name))
     time.sleep(int(config["DEFAULT"]['PollFrequency']))

--- a/dispatcher/dispatcher.py
+++ b/dispatcher/dispatcher.py
@@ -4,60 +4,81 @@ import argparse
 import datetime
 import logging
 import logging.handlers
+import threading
+import signal
 
 from MongoConnect import MongoConnect
 from DAQController import DAQController, STATUS
 
-# Parse command line
-parser = argparse.ArgumentParser(description='Manage the DAQ')
-parser.add_argument('--config', type=str, help='Path to your configuration file',
-        default='config.ini')
-parser.add_argument('--log', type=str, help='Logging level', default='DEBUG',
-        choices=['DEBUG','INFO','WARNING','ERROR','CRITICAL'])
-args = parser.parse_args()
-config = configparser.ConfigParser()
-config.read(args.config)
-logger = logging.getLogger('main')
-f = logging.Formatter(fmt='%(asctime)s | %(levelname)s | %(message)s')
-h = logging.StreamHandler()
-h.setFormatter(f)
-logger.addHandler(h)
-h = logging.handlers.TimedRotatingFileHandler(
-    'log_',when='midnight', utc=True,backupCount=7)
-h.setFormatter(f)
-logger.addHandler(h)
-logger.setLevel(getattr(logging, args.log))
-print("Config arm timeout: %i"%int(config["DEFAULT"]["ArmCommandTimeout"]))
-# Declare database object
-MongoConnector = MongoConnect(config, logger)
 
-# Declare a 'brain' object. This will cache info about the DAQ state in order to
-# solve the want/have decisions. The deciding functions also go here. It needs a
-# mongo connector because it has to pull options files
-DAQControl = DAQController(config, MongoConnector, logger)
-sleep_period = int(config['DEFAULT']['PollFrequency'])
+class SignalHandler(object):
+    def __init__(self):
+        self.event = threading.Event()
+        signal.signal(signal.SIGINT, self.interrupt)
+        signal.signal(signal.SIGTERM, self.interrupt)
 
-while(1):
-    time.sleep(sleep_period)
+    def interrupt(self, *args):
+        self.event.set()
 
-    # Get most recent check-in from all connected hosts
-    MongoConnector.GetUpdate()
-    latest_status = MongoConnector.latest_status
 
-    # Get most recent goal state from database. Users will update this from the website.
-    goal_state = MongoConnector.GetWantedState()
-    if goal_state is None:
-        continue
+def main():
 
-    # Decision time. Are we actually in our goal state? If not what should we do?
-    DAQControl.SolveProblem(latest_status, goal_state)
-    MongoConnector.ProcessCommands()
+    # Parse command line
+    parser = argparse.ArgumentParser(description='Manage the DAQ')
+    parser.add_argument('--config', type=str, help='Path to your configuration file',
+            default='config.ini')
+    parser.add_argument('--log', type=str, help='Logging level', default='DEBUG',
+            choices=['DEBUG','INFO','WARNING','ERROR','CRITICAL'])
+    args = parser.parse_args()
+    config = configparser.ConfigParser()
+    config.read(args.config)
+    logger = logging.getLogger('main')
+    f = logging.Formatter(fmt='%(asctime)s | %(levelname)s | %(message)s')
+    h = logging.StreamHandler()
+    h.setFormatter(f)
+    logger.addHandler(h)
+    h = logging.handlers.TimedRotatingFileHandler(
+        'log_',when='midnight', utc=True,backupCount=7)
+    h.setFormatter(f)
+    logger.addHandler(h)
+    logger.setLevel(getattr(logging, args.log))
+    # Declare database object
+    MongoConnector = MongoConnect(config, logger)
 
-    # Time to report back
-    MongoConnector.UpdateAggregateStatus()
+    # Declare a 'brain' object. This will cache info about the DAQ state in order to
+    # solve the want/have decisions. The deciding functions also go here. It needs a
+    # mongo connector because it has to pull options files
+    DAQControl = DAQController(config, MongoConnector, logger)
+    sleep_period = int(config['DEFAULT']['PollFrequency'])
+    sh = SignalHandler()
 
-    # Print an update
-    for detector in latest_status.keys():
-        logger.debug("Detector %s should be %sACTIVE and is %s"%(
-                detector, '' if goal_state[detector]['active'] == 'true' else 'IN',
-                latest_status[detector]['status'].name))
+    while(not sh.event.is_set()):
+        sh.event.wait(sleep_period)
+
+        # Get most recent check-in from all connected hosts
+        MongoConnector.GetUpdate()
+        latest_status = MongoConnector.latest_status
+
+        # Get most recent goal state from database. Users will update this from the website.
+        goal_state = MongoConnector.GetWantedState()
+        if goal_state is None:
+            continue
+
+        # Decision time. Are we actually in our goal state? If not what should we do?
+        DAQControl.SolveProblem(latest_status, goal_state)
+        MongoConnector.ProcessCommands()
+
+        # Time to report back
+        MongoConnector.UpdateAggregateStatus()
+
+        # Print an update
+        for detector in latest_status.keys():
+            logger.debug("Detector %s should be %sACTIVE and is %s"%(
+                    detector, '' if goal_state[detector]['active'] == 'true' else 'IN',
+                        latest_status[detector]['status'].name))
+
+    return
+
+
+if __name__ == '__main__':
+    main()

--- a/dispatcher/dispatcher.py
+++ b/dispatcher/dispatcher.py
@@ -56,7 +56,8 @@ def main():
         sh.event.wait(sleep_period)
 
         # Get most recent check-in from all connected hosts
-        MongoConnector.GetUpdate()
+        if MongoConnector.GetUpdate():
+            continue
         latest_status = MongoConnector.latest_status
 
         # Get most recent goal state from database. Users will update this from the website.
@@ -66,7 +67,6 @@ def main():
 
         # Decision time. Are we actually in our goal state? If not what should we do?
         DAQControl.SolveProblem(latest_status, goal_state)
-        MongoConnector.ProcessCommands()
 
         # Time to report back
         MongoConnector.UpdateAggregateStatus()
@@ -75,7 +75,7 @@ def main():
         for detector in latest_status.keys():
             logger.debug("Detector %s should be %sACTIVE and is %s"%(
                     detector, '' if goal_state[detector]['active'] == 'true' else 'IN',
-                        latest_status[detector]['status'].name))
+                    latest_status[detector]['status'].name))
 
     return
 

--- a/dispatcher/dispatcher.py
+++ b/dispatcher/dispatcher.py
@@ -1,7 +1,5 @@
-import time
 import configparser
 import argparse
-import datetime
 import logging
 import logging.handlers
 import threading
@@ -52,7 +50,7 @@ def main():
     sleep_period = int(config['DEFAULT']['PollFrequency'])
     sh = SignalHandler()
 
-    while(not sh.event.is_set()):
+    while(sh.event.is_set() == False):
         sh.event.wait(sleep_period)
 
         # Get most recent check-in from all connected hosts
@@ -64,7 +62,6 @@ def main():
         goal_state = MongoConnector.GetWantedState()
         if goal_state is None:
             continue
-
         # Decision time. Are we actually in our goal state? If not what should we do?
         DAQControl.SolveProblem(latest_status, goal_state)
 
@@ -76,7 +73,7 @@ def main():
             logger.debug("Detector %s should be %sACTIVE and is %s"%(
                     detector, '' if goal_state[detector]['active'] == 'true' else 'IN',
                     latest_status[detector]['status'].name))
-
+    MongoConnector.Quit()
     return
 
 

--- a/dispatcher/dispatcher.py
+++ b/dispatcher/dispatcher.py
@@ -35,8 +35,10 @@ MongoConnector = MongoConnect(config, logger)
 # solve the want/have decisions. The deciding functions also go here. It needs a
 # mongo connector because it has to pull options files
 DAQControl = DAQController(config, MongoConnector, logger)
+sleep_period = int(config['DEFAULT']['PollFrequency'])
 
 while(1):
+    time.sleep(sleep_period)
 
     # Get most recent check-in from all connected hosts
     MongoConnector.GetUpdate()
@@ -44,6 +46,8 @@ while(1):
 
     # Get most recent goal state from database. Users will update this from the website.
     goal_state = MongoConnector.GetWantedState()
+    if goal_state is None:
+        continue
 
     # Decision time. Are we actually in our goal state? If not what should we do?
     DAQControl.SolveProblem(latest_status, goal_state)
@@ -57,4 +61,3 @@ while(1):
         logger.debug("Detector %s should be %sACTIVE and is %s"%(
                 detector, '' if goal_state[detector]['active'] == 'true' else 'IN',
                 latest_status[detector]['status'].name))
-    time.sleep(int(config["DEFAULT"]['PollFrequency']))

--- a/main.cc
+++ b/main.cc
@@ -28,11 +28,13 @@ void UpdateStatus(std::string suri, std::string dbname, DAQController* controlle
   mongocxx::uri uri(suri);
   mongocxx::client c(uri);
   mongocxx::collection status = c[dbname]["status"];
+  using namespace std::chrono;
   while (b_run == true) {
     try{
       // Put in status update document
       auto insert_doc = bsoncxx::builder::stream::document{};
       insert_doc << "host" << hostname <<
+        "time" << duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count()<<
 	"rate" << controller->GetDataSize()/1e6 <<
 	"status" << controller->status() <<
 	"buffer_length" << controller->GetBufferLength() <<

--- a/main.cc
+++ b/main.cc
@@ -187,16 +187,16 @@ int main(int argc, char** argv){
 	      }
 	    }
 
-	    logger->Entry(MongoLog::Message, "Received start command from user %s",
-			  user.c_str());
+	    //logger->Entry(MongoLog::Message, "Received start command from user %s",
+	//		  user.c_str());
 	  }
 	  else
 	    logger->Entry(MongoLog::Debug, "Cannot start DAQ since not in ARMED state");
 	}
 	else if(command == "stop"){
 	  // "stop" is also a general reset command and can be called any time
-	  logger->Entry(MongoLog::Message, "Received stop command from user %s",
-			user.c_str());
+	  //logger->Entry(MongoLog::Message, "Received stop command from user %s",
+	//		user.c_str());
 	  if(controller->Stop()!=0)
 	    logger->Entry(MongoLog::Error,
 			  "DAQ failed to stop. Will continue clearing program memory.");
@@ -276,7 +276,6 @@ int main(int argc, char** argv){
 		throw std::runtime_error("Error while arming");
 	      }
 	      for(unsigned int i=0; i<links.size(); i++){
-		std::cout<<"Starting readout thread for link "<<links[i]<<std::endl;
 		std:: thread *readoutThread = new std::thread
 		  (
 		   &DAQController::ReadData, controller, links[i]);
@@ -294,7 +293,6 @@ int main(int argc, char** argv){
       std::cout<<"Can't connect to DB so will continue what I'm doing"<<std::endl;
     }
 
-    // Insert some information on this readout node back to the monitor DB
     controller->CheckErrors();
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }

--- a/main.cc
+++ b/main.cc
@@ -131,15 +131,14 @@ int main(int argc, char** argv){
       auto opts = mongocxx::options::find{};
       opts.sort(order.view());
       
-      mongocxx::cursor cursor = control.find 
-	(
+      mongocxx::cursor cursor = control.find(
 	 bsoncxx::builder::stream::document{} << "host" << hostname << "acknowledged." + hostname <<
 	 bsoncxx::builder::stream::open_document << "$exists" << 0 <<
 	 bsoncxx::builder::stream::close_document << 
 	 bsoncxx::builder::stream::finalize, opts
 	 );
 
-      for(auto doc : cursor) {	
+      for(auto doc : cursor) {
 	logger->Entry(MongoLog::Debug, "Found a doc with command %s",
 	  doc["command"].get_utf8().value.to_string().c_str());
 	// Very first thing: acknowledge we've seen the command. If the command
@@ -280,13 +279,11 @@ int main(int argc, char** argv){
 		throw std::runtime_error("Error while arming");
 	      }
 	      for(unsigned int i=0; i<links.size(); i++){
-		std:: thread *readoutThread = new std::thread
-		  (
-		   &DAQController::ReadData, controller, links[i]);
-		readoutThreads.push_back(readoutThread);
+                readoutThreads.emplace_back(new std::thread(&DAQController::ReadData,
+                      controller, links[i]));
 	      }
 	    }
-	  }
+	  } // if status is ok
 	  else
 	    logger->Entry(MongoLog::Warning, "Cannot arm DAQ while not 'Idle'");
 	} else if (command == "quit") b_run = false;

--- a/monitor/ceph_monitor.py
+++ b/monitor/ceph_monitor.py
@@ -51,7 +51,7 @@ def CheckStatus():
     
     result = subprocess.check_output(['ceph', 'status'])
     lines = result.decode().split('\n')
-    ret = {}
+    ret = {'time' : time.time()*1000}
     for line in lines:
         
         res_list = [a.strip() for a in line.split(' ') if a != '']
@@ -81,7 +81,7 @@ def CheckStatus():
         #    ret['wt_op_s'] = int(res_list[10])
     return ret
 
-client = MongoClient("mongodb://daq:%s@xenon1t-daq:27020,old-gw:27020/daq"%os.environ["MONGO_PASSWORD_DAQ"])
+client = MongoClient("mongodb://daq:%s@xenon1t-daq:27017/admin"%os.environ["MONGO_PASSWORD_DAQ"])
 db = client['daq']
 coll = db['system_monitor']
 while(1):

--- a/monitor/monitor.py
+++ b/monitor/monitor.py
@@ -1,41 +1,47 @@
 from pymongo import MongoClient
 import os
 import psutil
-import time
-import datetime
 timeout = 2
 import socket
+import re
+import signal
+import threading
 
-client = MongoClient("mongodb://daq:%s@xenon1t-daq:27020/daq"%os.environ["MONGO_PASSWORD_DAQ"])
+client = MongoClient("mongodb://daq:%s@xenon1t-daq:27020/daq"%os.environ["DAQ_PASSWORD"])
 db = client['daq']
 collection = db['system_monitor']
 
-while(1):
+ev = threading.Event()
+
+signal.signal(signal.SIGINT, lambda num, frame : ev.set())
+signal.signal(signal.SIGTERM, lambda num, frame : ev.set())
+
+while not ev.is_set():
 
     ret_doc = {'host': socket.gethostname()}
 
     # CPU
-    ret_doc['cpu_times'] = dict(psutil.cpu_times()._asdict())
     ret_doc['cpu_percent'] = psutil.cpu_percent()
-    ret_doc['cpu_percent_percpu'] = psutil.cpu_percent(percpu=True)
+    ret_doc['cpu_count'] = psutil.cpu_count(False)
     ret_doc['cpu_count_logical'] = psutil.cpu_count()
-    ret_doc['cpu_count'] = psutil.cpu_count(logical=False)
-
 
     # MEM
-    ret_doc['virtual_memory'] = dict(psutil.virtual_memory()._asdict())
-    ret_doc['swap_memory'] = dict(psutil.swap_memory()._asdict())
+    keep = ['total', 'percent']
+    virt_mem = dict(psutil.virtual_memory()._asdict())
+    ret_doc['virtual_memory'] = {k:virt_mem[k] for k in keep}
+    swap_mem = dict(psutil.swap_memory()._asdict())
+    ret_doc['swap_memory'] = {k:swap_mem[k] for k in keep}
 
     # DISK
     disk = {}
-    disk_partitions = psutil.disk_partitions(all=False)
-    for partition in disk_partitions:
+    pattern = '^/(data[0-9]?)?$'
+    for partition in psutil.disk_partitions():
         mount = partition.mountpoint
-        device = partition.device
-        disk[mount] = dict(psutil.disk_usage(mount)._asdict())
-        disk[mount]['device'] = device
+        if re.match(pattern, mount) is not None:
+            d = dict(psutil.disk_usage(mount)._asdict())
+            disk[mount] = {k:d[k] for k in keep}
     ret_doc['disk'] = disk
-    
-    #print(ret_doc)
-    collection.insert(ret_doc)    
-    time.sleep(timeout)
+
+    collection.insert(ret_doc)
+    ev.wait(timeout)
+

--- a/monitor/monitor.py
+++ b/monitor/monitor.py
@@ -6,8 +6,9 @@ import socket
 import re
 import signal
 import threading
+import time
 
-client = MongoClient("mongodb://daq:%s@xenon1t-daq:27020/daq"%os.environ["DAQ_PASSWORD"])
+client = MongoClient("mongodb://daq:%s@xenon1t-daq:27017/admin"%os.environ["MONGO_PASSWORD_DAQ"])
 db = client['daq']
 collection = db['system_monitor']
 
@@ -18,7 +19,7 @@ signal.signal(signal.SIGTERM, lambda num, frame : ev.set())
 
 while not ev.is_set():
 
-    ret_doc = {'host': socket.gethostname()}
+    ret_doc = {'host': socket.gethostname(), 'time' : time.time()*1000}
 
     # CPU
     ret_doc['cpu_percent'] = psutil.cpu_percent()


### PR DESCRIPTION
Rather than have processes blindly say "yes I saw this command", they now say "I saw this command at <insert ms-precise timestamp here>". This enables a much finer measurement of the run length, as we can now track much more precisely when the crate controller starts or ends the S-IN signal.

To facilitate this, the dispatcher will cache commands temporarily in the database, and a thread runs asynchronously to ensure that the commands are issued very close to the desired time.