### PR TITLE
Fix off-by-one error in record sorting

### DIFF
--- a/StraxInserter.cc
+++ b/StraxInserter.cc
@@ -392,7 +392,7 @@ void StraxInserter::ParseDocuments(data_packet* dp){
 int StraxInserter::AddFragmentToBuffer(std::string& fragment, int64_t timestamp) {
   // Get the CHUNK and decide if this event also goes into a PRE/POST file
   int chunk_id = timestamp/fFullChunkLength;
-  bool nextpre = (chunk_id+1)* fFullChunkLength - timestamp < fChunkOverlap;
+  bool nextpre = (chunk_id+1)* fFullChunkLength - timestamp <= fChunkOverlap;
   // Minor mess to maintain the same width of file names and do the pre/post stuff
   // If not in pre/post
   std::string chunk_index = std::to_string(chunk_id);


### PR DESCRIPTION
Strax assumes the redax sorts data into chunks that have half-open [x,y) time ranges. 

A fragment at `timestamp = fFullChunkLength` should be in the main chunk 1; redax [does this correctly](https://github.com/coderdj/redax/blob/d59529906b36a077068b0f57f3e6253bc3247f43/StraxInserter.cc#L394).

A fragment at `timestamp = fFullChunkLength - fChunkOverlap` should be in the pre/post files of chunk 0. However, redax assigns it to the main chunk 0, since
```
bool nextpre = (chunk_id+1)* fFullChunkLength - timestamp < fChunkOverlap; 
             = fFullChunkLength - (fFullChunkLength -  fChunkOverlap) < fChunkOverlap; 
             = fChunkOverlap < fChunkOverlap; 
```
is false.

This PR changes the `<` to `<= `in the last statement.
