### PR TITLE
Reduces unnecessary data saving

### DIFF
--- a/monitor/monitor.py
+++ b/monitor/monitor.py
@@ -7,7 +7,7 @@ import re
 import signal
 import threading
 
-client = MongoClient("mongodb://daq:%s@xenon1t-daq:27020/daq"%os.environ["MONGO_PASSWORD_DAQ"])
+client = MongoClient("mongodb://daq:%s@xenon1t-daq:27020/daq"%os.environ["DAQ_PASSWORD"])
 db = client['daq']
 collection = db['system_monitor']
 

--- a/monitor/monitor.py
+++ b/monitor/monitor.py
@@ -34,7 +34,7 @@ while not ev.is_set():
 
     # DISK
     disk = {}
-    pattern = '^/(data[0-9])?$'
+    pattern = '^/(data[0-9]?)?$'
     for partition in psutil.disk_partitions():
         mount = partition.mountpoint
         if re.match(pattern, mount) is not None:

--- a/monitor/monitor.py
+++ b/monitor/monitor.py
@@ -2,40 +2,48 @@ from pymongo import MongoClient
 import os
 import psutil
 import time
-import datetime
 timeout = 2
 import socket
+import re
+import signal
+import threading
 
 client = MongoClient("mongodb://daq:%s@xenon1t-daq:27020/daq"%os.environ["MONGO_PASSWORD_DAQ"])
 db = client['daq']
 collection = db['system_monitor']
 
-while(1):
+ev = threading.event()
+
+signal.signal(signal.SIGINT, lambda num, frame : ev.set())
+signal.signal(signal.SIGTERM, lambda num, frame : ev.set())
+signal.signal(signal.SIGBREAK, lambda num, frame : ev.set())
+
+while not ev.is_set():
 
     ret_doc = {'host': socket.gethostname()}
 
     # CPU
-    ret_doc['cpu_times'] = dict(psutil.cpu_times()._asdict())
     ret_doc['cpu_percent'] = psutil.cpu_percent()
-    ret_doc['cpu_percent_percpu'] = psutil.cpu_percent(percpu=True)
+    ret_doc['cpu_count'] = psutil.cpu_count(False)
     ret_doc['cpu_count_logical'] = psutil.cpu_count()
-    ret_doc['cpu_count'] = psutil.cpu_count(logical=False)
-
 
     # MEM
-    ret_doc['virtual_memory'] = dict(psutil.virtual_memory()._asdict())
-    ret_doc['swap_memory'] = dict(psutil.swap_memory()._asdict())
+    keep = ['total', 'percent']
+    virt_mem = dict(psutil.virtual_memory()._asdict())
+    ret_doc['virtual_memory'] = {k:virt_mem[k] for k in keep}
+    swap_mem = dict(psutil.swap_memory()._asdict())
+    ret_doc['swap_memory'] = {k:swap_mem[k] for k in keep}
 
     # DISK
     disk = {}
-    disk_partitions = psutil.disk_partitions(all=False)
-    for partition in disk_partitions:
+    pattern = '^/(data[0-9])?$'
+    for partition in psutil.disk_partitions():
         mount = partition.mountpoint
-        device = partition.device
-        disk[mount] = dict(psutil.disk_usage(mount)._asdict())
-        disk[mount]['device'] = device
+        if re.match(pattern, mount) is not None:
+            d = dict(psutil.disk_usage(mount)._asdict())
+            disk[mount] = {k:d[k] for k in keep}
     ret_doc['disk'] = disk
-    
-    #print(ret_doc)
-    collection.insert(ret_doc)    
-    time.sleep(timeout)
+
+    collection.insert(ret_doc)
+    ev.wait(timeout)
+

--- a/monitor/monitor.py
+++ b/monitor/monitor.py
@@ -15,7 +15,6 @@ ev = threading.Event()
 
 signal.signal(signal.SIGINT, lambda num, frame : ev.set())
 signal.signal(signal.SIGTERM, lambda num, frame : ev.set())
-signal.signal(signal.SIGBREAK, lambda num, frame : ev.set())
 
 while not ev.is_set():
 

--- a/monitor/monitor.py
+++ b/monitor/monitor.py
@@ -1,7 +1,6 @@
 from pymongo import MongoClient
 import os
 import psutil
-import time
 timeout = 2
 import socket
 import re
@@ -12,7 +11,7 @@ client = MongoClient("mongodb://daq:%s@xenon1t-daq:27020/daq"%os.environ["MONGO_
 db = client['daq']
 collection = db['system_monitor']
 
-ev = threading.event()
+ev = threading.Event()
 
 signal.signal(signal.SIGINT, lambda num, frame : ev.set())
 signal.signal(signal.SIGTERM, lambda num, frame : ev.set())


### PR DESCRIPTION
The system monitors on the various readers and eb's fill the 1 GB cap limit on the collection in less than one day. Most of the data isn't of particular interest (if it isn't displayed on the website it'll never be looked at), so a considerably longer period of historical sysmon data can be stored if what is actually stored is chosen more carefully