### PR TITLE
Timestamp issues

### DIFF
--- a/DAQController.cc
+++ b/DAQController.cc
@@ -482,6 +482,12 @@ void DAQController::InitLink(std::vector<V1724*>& digis,
     fLog->Entry(MongoLog::Local, "Board %i survived baseline mode. Going into register setting",
 		bid);
 
+    if (digi->Reset()) {
+      fLog->Entry(MongoLog::Error, "Could not reset digi %i", bid);
+      ret = -2;
+      return;
+    }
+
     for(auto regi : fOptions->GetRegisters(bid)){
       unsigned int reg = DAXHelpers::StringToHex(regi.reg);
       unsigned int val = DAXHelpers::StringToHex(regi.val);

--- a/DAQController.cc
+++ b/DAQController.cc
@@ -482,12 +482,6 @@ void DAQController::InitLink(std::vector<V1724*>& digis,
     fLog->Entry(MongoLog::Local, "Board %i survived baseline mode. Going into register setting",
 		bid);
 
-    if (digi->Reset()) {
-      fLog->Entry(MongoLog::Error, "Could not reset digi %i", bid);
-      ret = -2;
-      return;
-    }
-
     for(auto regi : fOptions->GetRegisters(bid)){
       unsigned int reg = DAXHelpers::StringToHex(regi.reg);
       unsigned int val = DAXHelpers::StringToHex(regi.val);

--- a/Options.cc
+++ b/Options.cc
@@ -377,7 +377,7 @@ void Options::UpdateDAC(std::map<int, std::map<std::string, std::vector<double>>
 
 void Options::SaveBenchmarks(std::map<std::string, long>& byte_counter,
     std::map<int, long>& buffer_counter,
-    double proc_time_us, double comp_time_us) {
+    double proc_time_dp_us, double proc_time_ev_us, double proc_time_ch_us, double comp_time_us) {
   using namespace bsoncxx::builder::stream;
   std::string run_id = GetString("run_identifier", "latest");
   auto search_doc = document{} << "run" << run_id << finalize;
@@ -389,7 +389,9 @@ void Options::SaveBenchmarks(std::map<std::string, long>& byte_counter,
   update_doc << "fragments" << byte_counter["fragments"];
   update_doc << "events" << byte_counter["events"];
   update_doc << "data_packets" << byte_counter["data_packets"];
-  update_doc << "processing_time_us" << proc_time_us;
+  update_doc << "processing_time_dp_us" << proc_time_dp_us;
+  update_doc << "processing_time_ev_us" << proc_time_ev_us;
+  update_doc << "processing_time_ch_us" << proc_time_ch_us;
   update_doc << "compression_time_us" << comp_time_us;
   update_doc << "buffer_xfers" << open_document;
   for (auto& p : buffer_counter) {

--- a/Options.hh
+++ b/Options.hh
@@ -86,7 +86,7 @@ public:
   std::vector<u_int16_t> GetThresholds(int board);
 
   void UpdateDAC(std::map<int, std::map<std::string, std::vector<double>>>&);
-  void SaveBenchmarks(std::map<std::string, long>&, std::map<int, long>&, double, double);
+  void SaveBenchmarks(std::map<std::string, long>&, std::map<int, long>&, double, double, double, double);
 private:
   mongocxx::client fClient;
   bsoncxx::document::view bson_options;

--- a/StraxInserter.cc
+++ b/StraxInserter.cc
@@ -386,7 +386,7 @@ int StraxInserter::ReadAndInsertData(){
       } else {
         std::this_thread::sleep_for(sleep_time);
       }
-      if (++counter % 100 == 0) {
+      if (++counter % 100 == 0 && fFragments.size() > 0) {
         std::stringstream msg;
         msg << "Current chunks for thread " << fThreadId;
         for (auto& it : fFragments) msg << ' ' << it.first;

--- a/StraxInserter.cc
+++ b/StraxInserter.cc
@@ -469,7 +469,7 @@ void StraxInserter::WriteOutFiles(bool end){
 
     std::ofstream writefile(GetFilePath(chunk_index, true), std::ios::binary);
     writefile.write(out_buffer, wsize);
-    fLog->Entry(MongoLog::Local, "Thread %lx wrote chunk %s", fThreadId, chunk_index);
+//    fLog->Entry(MongoLog::Local, "Thread %lx wrote chunk %s", fThreadId, chunk_index.c_str());
     delete[] out_buffer;
     writefile.close();
 

--- a/StraxInserter.cc
+++ b/StraxInserter.cc
@@ -166,10 +166,11 @@ void StraxInserter::ProcessDatapacket(data_packet* dp){
 
     if(buff[idx]>>28 == 0xA){ // 0xA indicates header at those bits
       ev_start = system_clock::now();
-      idx = ProcessEvent(buff+idx, total_words-idx, dp->clock_counter, dp->header_time, dp->bid);
+      idx += ProcessEvent(buff+idx, total_words-idx, dp->clock_counter, dp->header_time, dp->bid);
       ev_end = system_clock::now();
       fProcTimeEv += duration_cast<microseconds>(ev_end - ev_start);
-    }
+    } else
+      idx++;
     if (fForceQuit) break;
   }
   proc_end = system_clock::now();
@@ -248,7 +249,6 @@ int StraxInserter::ProcessChannel(uint32_t* buff, unsigned words_in_event, int b
             bid, channel, channel_words, fmt["channel_header_words"]);
       return -1;
     }
-    channel_words -= fmt["channel_header_words"];
     channel_time = buff[1]&0xFFFFFFFF;
     fSawBit30 |= (channel_time & (1 << 30));
 
@@ -287,7 +287,7 @@ int StraxInserter::ProcessChannel(uint32_t* buff, unsigned words_in_event, int b
   }
 
   u_int16_t *payload = reinterpret_cast<u_int16_t*>(buff+fmt["channel_header_words"]);
-  u_int32_t samples_in_pulse = channel_words<<1;
+  u_int32_t samples_in_pulse = (channel_words-fmt["channel_header_words"])<<1;
   u_int16_t sw = fmt["ns_per_sample"];
   int fragment_samples = fFragmentBytes>>1;
   int16_t cl = fOptions->GetChannel(bid, channel);

--- a/StraxInserter.cc
+++ b/StraxInserter.cc
@@ -232,7 +232,7 @@ int StraxInserter::ProcessChannel(uint32_t* buff, unsigned words_in_event, int b
   u_int32_t channel_words = (words_in_event-event_header_words) / channels_in_event;
   long channel_time = (clock_counter<<31) + event_time;
   long channel_timeMSB = 0;
-  u_int16_t baseline_ch = clock_counter;
+  u_int16_t baseline_ch = 0;
   std::map<std::string, int> fmt = fFmt[bid];
 
   // Presence of a channel header indicates non-default firmware (DPP-DAW) so override

--- a/StraxInserter.cc
+++ b/StraxInserter.cc
@@ -424,7 +424,9 @@ void StraxInserter::WriteOutFiles(bool end){
     if (iter.first == "")
         continue; // not sure why, but this sometimes happens during bad shutdowns
     std::string chunk_index = iter.first;
-    if (std::stoi(iter.first) > write_lte && !end) continue;
+    if (std::stoi(chunk_index) > write_lte && !end) continue;
+    fLog->Entry(MongoLog::Local, "Thread %lx max %i current %i buffer %i write_lte %i",
+        fThreadId, max_chunk, std::stoi(chunk_index), fBufferNumChunks, write_lte);
 
     comp_start = system_clock::now();
     if(!fs::exists(GetDirectoryPath(chunk_index, true)))

--- a/StraxInserter.cc
+++ b/StraxInserter.cc
@@ -36,7 +36,6 @@ StraxInserter::StraxInserter(){
   fFullChunkLength = fChunkLength+fChunkOverlap;
   fFragmentsProcessed = 0;
   fEventsProcessed = 0;
-  somebool=true;
 }
 
 StraxInserter::~StraxInserter(){

--- a/StraxInserter.cc
+++ b/StraxInserter.cc
@@ -470,9 +470,10 @@ void StraxInserter::WriteOutFiles(bool end){
     writefile.close();
 
     // shenanigans or skulduggery?
-    /*if(fs::exists(GetFilePath(chunk_index, false))) {
-      fLog->Entry(MongoLog::Warning, "Chunk %s already exists????", chunk_index.c_str());
-    }*/
+    if(fs::exists(GetFilePath(chunk_index, false))) {
+      fLog->Entry(MongoLog::Warning, "Chunk %s from thread %lx already exists? Data loss warning",
+          chunk_index.c_str(), fThreadId);
+    }
 
     // Move this chunk from *_TEMP to the same path without TEMP
     if(!fs::exists(GetDirectoryPath(chunk_index, false)))

--- a/StraxInserter.cc
+++ b/StraxInserter.cc
@@ -11,6 +11,7 @@
 #include <sstream>
 #include <list>
 #include <bitset>
+#include <iomanip>
 
 namespace fs=std::experimental::filesystem;
 using namespace std::chrono;
@@ -386,9 +387,9 @@ int StraxInserter::ReadAndInsertData(){
       } else {
         std::this_thread::sleep_for(sleep_time);
       }
-      if (++counter % 100 == 0 && fFragments.size() > 0) {
+      if (((++counter) % 1000 == 0) && (fFragments.size() > 0)) {
         std::stringstream msg;
-        msg << "Current chunks for thread " << fThreadId;
+        msg << "Current chunks " << std::hex<<fThreadId<<std::dec;
         for (auto& it : fFragments) msg << ' ' << it.first;
         fLog->Entry(MongoLog::Local, msg.str());
       }

--- a/StraxInserter.cc
+++ b/StraxInserter.cc
@@ -388,12 +388,12 @@ int StraxInserter::ReadAndInsertData(){
       } else {
         std::this_thread::sleep_for(sleep_time);
       }
-      if (((++counter) % 1000 == 0) && (fFragments.size() > 0)) {
+      /*if (((++counter) % 1000 == 0) && (fFragments.size() > 0)) {
         std::stringstream msg;
         msg << "Current chunks " << std::hex<<fThreadId<<std::dec;
         for (auto& it : fFragments) msg << ' ' << it.first;
         fLog->Entry(MongoLog::Local, msg.str());
-      }
+      }*/
     }
   } else {
     data_packet* dp;

--- a/StraxInserter.cc
+++ b/StraxInserter.cc
@@ -176,7 +176,7 @@ void StraxInserter::ProcessDatapacket(data_packet* dp){
   }
   proc_end = system_clock::now();
   fProcTimeDP += duration_cast<microseconds>(proc_end - proc_start);
-
+  fBytesProcessed += dp->size;
   delete dp;
 }
 

--- a/StraxInserter.hh
+++ b/StraxInserter.hh
@@ -54,8 +54,10 @@ public:
   int GetBufferLength() {return fBufferLength.load();}
   
 private:
-  void ParseDocuments(data_packet *dp);
-  void WriteOutFiles(int smallest_index_seen, bool end=false);
+  void ProcessDatapacket(data_packet *dp);
+  uint32_t ProcessEvent(uint32_t*, unsigned, int, uint32_t, int);
+  int ProcessChannel(uint32_t*, unsigned, int, int, uint32_t, uint32_t, long, int);
+  void WriteOutFiles(bool end=false);
   void GenerateArtificialDeadtime(int64_t timestamp, int16_t bid);
   int AddFragmentToBuffer(std::string& fragment, int64_t timestamp);
 
@@ -69,6 +71,7 @@ private:
   int64_t fChunkOverlap; // ns
   int fFragmentBytes; // This is in BYTES
   int fStraxHeaderSize; // in BYTES too
+  int fBufferNumChunks;
   unsigned fChunkNameLength;
   int64_t fFullChunkLength;
   std::string fOutputPath, fHostname;
@@ -90,9 +93,9 @@ private:
   long fBytesProcessed;
   long fFragmentsProcessed;
   long fEventsProcessed;
+  bool fSawBit30;
 
-  std::chrono::microseconds fProcTime;
-  std::chrono::microseconds fCompTime;
+  std::chrono::microseconds fProcTimeDP, fProcTimeEv, fProcTimeCh, fCompTime;
   std::thread::id fThreadId;
 };
 

--- a/StraxInserter.hh
+++ b/StraxInserter.hh
@@ -94,7 +94,7 @@ private:
   long fBytesProcessed;
   long fFragmentsProcessed;
   long fEventsProcessed;
-  bool fSawBit30, somebool;
+  bool fSawBit30;
 
   std::chrono::microseconds fProcTimeDP, fProcTimeEv, fProcTimeCh, fCompTime;
   std::thread::id fThreadId;

--- a/StraxInserter.hh
+++ b/StraxInserter.hh
@@ -55,11 +55,11 @@ public:
   
 private:
   void ProcessDatapacket(data_packet *dp);
-  uint32_t ProcessEvent(uint32_t*, unsigned, int, uint32_t, int);
+  uint32_t ProcessEvent(uint32_t*, unsigned, long, uint32_t, int);
   int ProcessChannel(uint32_t*, unsigned, int, int, uint32_t, uint32_t, long, int);
   void WriteOutFiles(bool end=false);
   void GenerateArtificialDeadtime(int64_t timestamp, int16_t bid);
-  int AddFragmentToBuffer(std::string& fragment, int64_t timestamp);
+  void AddFragmentToBuffer(std::string& fragment, int64_t timestamp);
 
   std::experimental::filesystem::path GetFilePath(std::string id, bool temp);
   std::experimental::filesystem::path GetDirectoryPath(std::string id, bool temp);

--- a/StraxInserter.hh
+++ b/StraxInserter.hh
@@ -90,10 +90,11 @@ private:
   std::mutex fDPC_mutex;
   std::map<int, long> fBufferCounter;
   std::atomic_int fBufferLength;
+  std::map<std::string, std::chrono::system_clock::time_point> fTimeLastSeen;
   long fBytesProcessed;
   long fFragmentsProcessed;
   long fEventsProcessed;
-  bool fSawBit30;
+  bool fSawBit30, somebool;
 
   std::chrono::microseconds fProcTimeDP, fProcTimeEv, fProcTimeCh, fCompTime;
   std::thread::id fThreadId;

--- a/StraxInserter.hh
+++ b/StraxInserter.hh
@@ -94,7 +94,6 @@ private:
   long fBytesProcessed;
   long fFragmentsProcessed;
   long fEventsProcessed;
-  bool fSawBit30;
 
   std::chrono::microseconds fProcTimeDP, fProcTimeEv, fProcTimeCh, fCompTime;
   std::thread::id fThreadId;

--- a/V1724.cc
+++ b/V1724.cc
@@ -72,15 +72,6 @@ V1724::~V1724(){
     }
   }
   fLog->Entry(MongoLog::Local, msg.str());
-  if (fBID == 1410) {
-    std::ofstream fout("/live_data/xenonnt_data/1410_timestamps.bin", std::ios::binary);
-    for (unsigned i = 0; i < fRO.size(); i++) {
-      fout.write((char*)(fRO.data()+i), 4);
-      fout.write((char*)(fEV.data()+i), 4);
-      fout.write((char*)(fCH.data()+i), 4);
-    }
-    fout.close();
-  }
 }
 
 int V1724::SINStart(){
@@ -184,11 +175,6 @@ u_int32_t V1724::GetHeaderTime(u_int32_t *buff, u_int32_t size, u_int32_t& num){
   while(idx < size/sizeof(u_int32_t)){
     if(buff[idx]>>28==0xA){
       num = buff[idx+2]&0xFFFFFF;
-      if (fBID == 1410 && (buff[idx+1]&0x2)) {
-        fRO.push_back(clock_counter);
-        fEV.push_back(buff[idx+3]);
-        fCH.push_back(buff[idx+5]);
-      }
       return buff[idx+3]&0x7FFFFFFF;
     }
     idx++;

--- a/V1724.cc
+++ b/V1724.cc
@@ -1,6 +1,5 @@
 #include "V1724.hh"
 #include <numeric>
-#include <array>
 #include <algorithm>
 #include <bitset>
 #include <cmath>
@@ -15,6 +14,7 @@
 #include <sstream>
 #include <list>
 #include <utility>
+#include <fstream>
 
 
 V1724::V1724(MongoLog  *log, Options *options){
@@ -72,6 +72,15 @@ V1724::~V1724(){
     }
   }
   fLog->Entry(MongoLog::Local, msg.str());
+  if (fBID == 1410) {
+    std::ofstream fout("/live_data/xenonnt_data/1410_timestamps.bin", std::ios::binary);
+    for (unsigned i = 0; i < fRO.size(); i++) {
+      fout.write((char*)(fRO.data()+i), 4);
+      fout.write((char*)(fEV.data()+i), 4);
+      fout.write((char*)(fCH.data()+i), 4);
+    }
+    fout.close();
+  }
 }
 
 int V1724::SINStart(){
@@ -175,6 +184,11 @@ u_int32_t V1724::GetHeaderTime(u_int32_t *buff, u_int32_t size, u_int32_t& num){
   while(idx < size/sizeof(u_int32_t)){
     if(buff[idx]>>28==0xA){
       num = buff[idx+2]&0xFFFFFF;
+      if (fBID == 1410) {
+        fRO.push_back(clock_counter);
+        fEV.push_back(buff[idx+3]);
+        fCH.push_back(buff[idx+5]);
+      }
       return buff[idx+3]&0x7FFFFFFF;
     }
     idx++;

--- a/V1724.cc
+++ b/V1724.cc
@@ -184,7 +184,7 @@ u_int32_t V1724::GetHeaderTime(u_int32_t *buff, u_int32_t size, u_int32_t& num){
   while(idx < size/sizeof(u_int32_t)){
     if(buff[idx]>>28==0xA){
       num = buff[idx+2]&0xFFFFFF;
-      if (fBID == 1410) {
+      if (fBID == 1410 && (buff[idx+1]&0x2)) {
         fRO.push_back(clock_counter);
         fEV.push_back(buff[idx+3]);
         fCH.push_back(buff[idx+5]);

--- a/V1724.hh
+++ b/V1724.hh
@@ -83,7 +83,7 @@ protected:
   MongoLog *fLog;
 
   float fBLTSafety, fBufferSafety;
-
+  std::vector<uint32_t> fRO, fEV, fCH;
 };
 
 

--- a/V1724.hh
+++ b/V1724.hh
@@ -83,7 +83,7 @@ protected:
   MongoLog *fLog;
 
   float fBLTSafety, fBufferSafety;
-  std::vector<uint32_t> fRO, fEV, fCH;
+
 };
 
 


### PR DESCRIPTION
Fixes some issues relating to timestamps, including significant amounts of data getting overwritten when fragments show up slightly later than usual. Rearranges StraxInserter.cc to better handle control flow, and also simplifies the code to handle timestamp rollovers.