### PR TITLE
Database snafus bring down the processes

### DIFF
--- a/ccontrol.cc
+++ b/ccontrol.cc
@@ -74,14 +74,19 @@ int main(int argc, char** argv){
     
     for (auto doc : cursor) {
       // Acknowledge the commands
-      control.update_one
-        (bsoncxx::builder::stream::document{} << "_id" << doc["_id"].get_oid() <<
-         bsoncxx::builder::stream::finalize,
-         bsoncxx::builder::stream::document{} << "$push" <<
-         bsoncxx::builder::stream::open_document << "acknowledged" << hostname <<
-         bsoncxx::builder::stream::close_document <<
-         bsoncxx::builder::stream::finalize
-         );
+      try {
+        control.update_one
+          (bsoncxx::builder::stream::document{} << "_id" << doc["_id"].get_oid() <<
+            bsoncxx::builder::stream::finalize,
+            bsoncxx::builder::stream::document{} << "$push" <<
+            bsoncxx::builder::stream::open_document << "acknowledged" << hostname <<
+            bsoncxx::builder::stream::close_document <<
+            bsoncxx::builder::stream::finalize
+            );
+      } catch (...) {
+        std::cout<<"Can't access db, I'll keep doing my thing\n";
+        continue;
+      }
       
       // Strip data from the supplied doc
       int run = -1;
@@ -145,7 +150,11 @@ int main(int argc, char** argv){
     } //end for  
  
     // Report back on what we are doing
-    status.insert_one(fHandler->GetStatusDoc(hostname));
+    try{
+      status.insert_one(fHandler->GetStatusDoc(hostname));
+    } catch(...) {
+      std::cout<<"Couldn't update database, I'll keep doing my thing\n";
+    }
    usleep(1000000);
   }
   return 0;

--- a/dispatcher/DAQController.py
+++ b/dispatcher/DAQController.py
@@ -261,6 +261,8 @@ class DAQController():
                 delay = 0
                 if command == 'start':
                     run = self.mongo.InsertRunDoc(detector, self.goal_state)
+                    if run == -1:  # runs db having a moment
+                        return
             else: # stop
                 readers, cc = self.mongo.GetConfiguredNodes(detector,
                     self.goal_state['tpc']['link_mv'], self.goal_state['tpc']['link_nv'])

--- a/dispatcher/MongoConnect.py
+++ b/dispatcher/MongoConnect.py
@@ -1,4 +1,5 @@
 from pymongo import MongoClient
+from pymongo.errors import NotMasterError
 import datetime
 import os
 import json

--- a/dispatcher/dispatcher.py
+++ b/dispatcher/dispatcher.py
@@ -35,8 +35,10 @@ MongoConnector = MongoConnect(config, logger)
 # solve the want/have decisions. The deciding functions also go here. It needs a
 # mongo connector because it has to pull options files
 DAQControl = DAQController(config, MongoConnector, logger)
+sleep_period = int(config['DEFAULT']['PollFrequency'])
 
 while(1):
+    time.sleep(sleep_period)
 
     # Get most recent check-in from all connected hosts
     MongoConnector.GetUpdate()
@@ -44,6 +46,8 @@ while(1):
 
     # Get most recent goal state from database. Users will update this from the website.
     goal_state = MongoConnector.GetWantedState()
+    if goal_state is None:
+        continue
 
     # Decision time. Are we actually in our goal state? If not what should we do?
     DAQControl.SolveProblem(latest_status, goal_state)
@@ -57,4 +61,3 @@ while(1):
         logger.debug("Detector %s should be %sACTIVE and is %s"%(
                 detector, '' if goal_state[detector]['active'] == 'true' else 'IN',
                 latest_status[detector]['status'].name))
-    time.sleep(int(config["DEFAULT"]['PollFrequency']))


### PR DESCRIPTION
The other day the database had a snafu where xenon1t-daq briefly wasn't the master. The dispatcher and crate controllers crashed, but the readout didn't. All database calls from the readers are try-catch wrapped, while for the CC and the dispatcher it isn't. This PR addresses this.