### PR TITLE
Soft stop support

### DIFF
--- a/dispatcher/DAQController.py
+++ b/dispatcher/DAQController.py
@@ -105,16 +105,16 @@ class DAQController():
                     (latest_status['neutron_veto']['status']  in active_states and
                      goal_state['tpc']['link_nv'] == 'true')
             ):
-                self.StopDetectorGently(goal_state, latest_status, detector='tpc')
+                self.StopDetectorGently(detector='tpc')
 
         # 1b - deal with MV but only if MV not linked to TPC
         if goal_state['tpc']['link_mv'] == 'false' and goal_state['muon_veto']['active'] == 'false':
             if latest_status['muon_veto']['status']  in active_states:
-                self.StopDetectorGently(goal_state, latest_status, detector='muon_veto')
+                self.StopDetectorGently(detector='muon_veto')
         # 1c - deal with NV but only if NV not linked to TPC
         if goal_state['tpc']['link_nv'] == 'false' and goal_state['neutron_veto']['active'] == 'false':
             if latest_status['neutron_veto']['status']  in active_states:
-                self.StopDetectorGently(goal_state, latest_status, detector='neutron_veto')
+                self.StopDetectorGently(detector='neutron_veto')
 
         '''
         CASE 2: DETECTORS ARE ACTIVE
@@ -232,20 +232,19 @@ class DAQController():
 
         return
 
-    def StopDetectorGently(self, goal_state, latest_status, detector):
+    def StopDetectorGently(self, detector):
         '''
         Stops the detector, unless we're told to wait for the current
         run to end
         '''
         if (
                 # Running normally (not arming, error, timeout, etc)
-                latest_status[detector]['status'] == STATUS.RUNNING and
+                self.latest_status[detector]['status'] == STATUS.RUNNING and
                 # We were asked to wait for the current run to stop
-                goal_state[detector].get('finish_run_on_stop', 'false') == 'true'):
+                self.goal_state[detector].get('finish_run_on_stop', 'false') == 'true'):
             self.CheckRunTurnover(detector)
         else:
             self.ControlDetector(detector=detector, command='stop')
-            # self.CheckTimeouts(detector)
 
     def ControlDetector(self, command, detector, force=False):
         '''

--- a/docs/databases.md
+++ b/docs/databases.md
@@ -91,6 +91,7 @@ Because some of these fields require slightly more explanation a table has been 
         "detector" : "tpc", 
         "active" : "true",
         "stop_after" : "60",
+        "finish_run_on_stop": "true",
         "mode" : "two_boards_with_sync",
         "user" : "Coderre",
         "comment" : "",
@@ -106,6 +107,7 @@ Because some of these fields require slightly more explanation a table has been 
 |detector	|Either 'tpc', 'muon_veto', or 'neutron_veto'. Or whatever funny thing you've got in your lab. |
 |active	|The user can set whether this detector is 'active' or not. If it's not active then we don't care about it's status. In fact we can't care since some readers will be reused when running in combined modes and may not longer belong to their original detectors.|
 |stop_after	|How many minutes (or seconds? check code) until the run automatically restarts. This is a global DAQ state setting, not the setting for a single run. So if you want to run for an hour you set this to 60 minutes, put the detector active, and the dispatcher should handle giving you the 1 hour runs. |
+|finish_run_on_stop |How to deal with a run in progress if you set active to 'false'. If 'finish_run_on_stop' is true, we wait for the run to finish due to stop_after (but no new one is started). If false, we stop the run. Has no effect if active is 'true'. |    
 |mode	|The options mode we're running the DAQ in. Should correspond to the 'name' field of one of the documents in the options collection. |
 |user	|Who gets credit/blame for starting these runs? This is the user who last changed this command doc and it will be recorded in the run documents of all runs recorded while this command is active. |
 |Comment	|You can automatically connect a comment to all runs started with this setting by setting this field. The comment is put in the run doc for all runs started while the command is active. |


### PR DESCRIPTION
This adds a field `finish_run_on_stop` to the detector control collection. Currently the field is optional (and assumed `false` if omitted) since the website doesn't set it yet.

If a detector is running, the goal state is inactive, and this field is set to true, the dispatcher will call `CheckRunTurnover` rather than `ControlDetector(..., 'stop')`. This means the detector will be stopped only when the run finishes 'naturally', i.e. exceeds its `stop_after` time. If `finish_run_on_stop` is false we just stop the detector whether it is running or not.

There is no change in behavior for stops issued for other reasons (e.g. on errors) or for stops issued while the detector is an active but not running state (error, arming, etc).

I noticed the CheckTimeouts call was currently commented out after the stop commands. I left it that way.

The main motivation for this is to take specific run durations when switching between run modes, especially when this is done manually. An example is LED calibration or HV scans currently, but there will be more such instances during commissioning. 

(Note that even with this option on, runs turnover keeps happening unless you explicitly set the goal state to inactive. We still avoid the danger of shifters not taking data accidentally as we had in the XENON1T runlists era.)