### PR TITLE
Tweaks and cleanup for combined operation

### DIFF
--- a/CControl_Handler.cc
+++ b/CControl_Handler.cc
@@ -221,7 +221,7 @@ bsoncxx::document::value CControl_Handler::GetStatusDoc(std::string hostname){
 	      << bsoncxx::builder::stream::close_document; 
   }
   
-  //auto after_array = in_array << bsoncxx::builder::stream::close_array;
-  //return after_array << bsoncxx::builder::stream::finalize;
+  after_array = in_array << bsoncxx::builder::stream::close_array;
+  return after_array << bsoncxx::builder::stream::finalize;
 
 }  

--- a/CControl_Handler.cc
+++ b/CControl_Handler.cc
@@ -221,7 +221,7 @@ bsoncxx::document::value CControl_Handler::GetStatusDoc(std::string hostname){
 	      << bsoncxx::builder::stream::close_document; 
   }
   
-  auto after_array = in_array << bsoncxx::builder::stream::close_array;
-  return after_array << bsoncxx::builder::stream::finalize;
+  //auto after_array = in_array << bsoncxx::builder::stream::close_array;
+  //return after_array << bsoncxx::builder::stream::finalize;
 
 }  

--- a/DAQController.cc
+++ b/DAQController.cc
@@ -277,7 +277,7 @@ void DAQController::ReadData(int link){
         }
       }
       if (dp == nullptr) dp = new data_packet;
-      if((dp->size = digi->ReadMBLT(buff, &dp->vBLT))<0){
+      if((dp->size = digi->ReadMBLT(dp->buff))<0){
         if (dp->buff != nullptr) {
 	  delete[] dp->buff; // possible leak, catch here
 	  dp->buff = nullptr;

--- a/Options.cc
+++ b/Options.cc
@@ -14,7 +14,7 @@
 
 Options::Options(MongoLog *log, std::string options_name, std::string hostname,
           std::string suri, std::string dbname, std::string override_opts) : 
-    fLog(log), fDBName(dbname), fHostname(hostname) {
+    fLog(log), fDBname(dbname), fHostname(hostname) {
   bson_value = NULL;
   mongocxx::uri uri{suri};
   fClient = mongocxx::client{uri};
@@ -71,7 +71,7 @@ int Options::Load(std::string name, mongocxx::collection& opts_collection,
     return -1;
   }
   try{
-    fDetector = bson_options["detectors"][hostname].get_utf8().value.to_string();
+    fDetector = bson_options["detectors"][fHostname].get_utf8().value.to_string();
   }catch(const std::exception& e){
     fLog->Entry(MongoLog::Warning, "No detector specified for this host");
     return -1;
@@ -229,7 +229,7 @@ std::vector<RegisterType> Options::GetRegisters(int board, bool strict){
         sdet = ele["board"].get_utf8().value.to_string();
         ibid = -1;
       }catch(const std::exception& ee){
-        throw std::exception("Invalid register: board is neither int nor string");
+        throw std::runtime_error("Invalid register: board is neither int nor string");
       }
     }
     if ((ibid != board) && strict) continue;
@@ -423,7 +423,8 @@ void Options::SaveBenchmarks(std::map<std::string, long>& byte_counter,
     update_doc << close_document; // buffer xfers
   }
 
-  update_doc << close_document << close_document; // push
+  update_doc << close_document; // data
+  update_doc << close_document; // push
   auto write_doc = update_doc << finalize;
   mongocxx::options::update options;
   options.upsert(true);

--- a/Options.cc
+++ b/Options.cc
@@ -11,13 +11,11 @@
 #include <bsoncxx/exception/exception.hpp>
 
 Options::Options(MongoLog *log, std::string options_name, std::string hostname,
-          std::string suri, std::string dbname, std::string override_opts){
+          std::string suri, std::string dbname, std::string override_opts) : 
+    fLog(log), fDBName(dbname), fHostname(hostname) {
   bson_value = NULL;
-  fLog = log;
-  fHostname = hostname;
   mongocxx::uri uri{suri};
   fClient = mongocxx::client{uri};
-  fDBname = dbname;
   fDAC_collection = fClient[dbname]["dac_calibration"];
   mongocxx::collection opts_collection = fClient[dbname]["options"];
   if(Load(options_name, opts_collection, override_opts)!=0)
@@ -29,11 +27,6 @@ Options::~Options(){
     delete bson_value;
     bson_value = NULL;
   }
-}
-
-std::string Options::ExportToString(){
-  std::string ret = bsoncxx::to_json(bson_options);
-  return ret;
 }
 
 int Options::Load(std::string name, mongocxx::collection& opts_collection,
@@ -52,7 +45,7 @@ int Options::Load(std::string name, mongocxx::collection& opts_collection,
   }
   bson_value = new bsoncxx::document::value((*trydoc).view());
   bson_options = bson_value->view();
-  
+
   // Pull all subdocuments
   int success = 0;
   try{
@@ -75,7 +68,12 @@ int Options::Load(std::string name, mongocxx::collection& opts_collection,
     fLog->Entry(MongoLog::Warning, "Failed to override options doc with includes and overrides.");
     return -1;
   }
-
+  try{
+    fDetector = bson_options["detectors"][hostname].get_utf8().value.to_string();
+  }catch(const std::exception& e){
+    fLog->Entry(MongoLog::Warning, "No detector specified for this host");
+    return -1;
+  }
 
   return 0;
 }
@@ -123,7 +121,7 @@ long int Options::GetLongInt(std::string path, long int default_value){
       fLog->Entry(MongoLog::Local, "Using default value for %s", path.c_str());
       return default_value;
     }
-  }  
+  }
   return -1;
 }
 
@@ -139,14 +137,14 @@ double Options::GetDouble(std::string path, double default_value) {
 int Options::GetInt(std::string path, int default_value){
 
   try{
-    return bson_options[path.c_str()].get_int32();
+    return bson_options[path].get_int32();
   }
   catch (const std::exception &e){
     //LOG
     fLog->Entry(MongoLog::Local, "Using default value for %s", path.c_str());
     return default_value;
   }
-  return -1;  
+  return -1;
 }
 
 int Options::GetNestedInt(std::string path, int default_value){
@@ -159,9 +157,9 @@ int Options::GetNestedInt(std::string path, int default_value){
     fields.push_back( substr );
   }
   try{
-    auto val = bson_options[fields[0].c_str()];
+    auto val = bson_options[fields[0]];
     for(unsigned int i=1; i<fields.size(); i++)
-      val = val[fields[i].c_str()];
+      val = val[fields[i]];
     return val.get_int32();
   }catch(const std::exception &e){
     fLog->Entry(MongoLog::Local, "Using default value for %s",path.c_str());
@@ -172,17 +170,17 @@ int Options::GetNestedInt(std::string path, int default_value){
 
 std::string Options::GetString(std::string path, std::string default_value){
   try{
-    return bson_options[path.c_str()].get_utf8().value.to_string();
+    return bson_options[path].get_utf8().value.to_string();
   }
   catch (const std::exception &e){
     //LOG
     fLog->Entry(MongoLog::Local, "Using default value for %s", path.c_str());
     return default_value;
-  }  
+  }
   return "";
 }
 
-std::vector<BoardType> Options::GetBoards(std::string type, std::string hostname){
+std::vector<BoardType> Options::GetBoards(std::string type){
   std::vector<BoardType> ret;
   bsoncxx::array::view subarr = bson_options["boards"].get_array().value;
 
@@ -197,8 +195,8 @@ std::vector<BoardType> Options::GetBoards(std::string type, std::string hostname
     if(!std::count(types.begin(), types.end(), btype))
       continue;
     try{
-      if(ele["host"].get_utf8().value.to_string() != hostname)
-	continue;
+      if(ele["host"].get_utf8().value.to_string() != fHostname)
+        continue;
     }
     catch(const std::exception &e){
       // If there is no host field then no biggie. Assume we have just 1 host.
@@ -207,27 +205,39 @@ std::vector<BoardType> Options::GetBoards(std::string type, std::string hostname
     bt.link = ele["link"].get_int32();
     bt.crate = ele["crate"].get_int32();
     bt.board = ele["board"].get_int32();
-    bt.type = ele["type"].get_utf8().value.to_string();    
+    bt.type = ele["type"].get_utf8().value.to_string();
     bt.vme_address = DAXHelpers::StringToHex(ele["vme_address"].get_utf8().value.to_string());
     ret.push_back(bt);
   }
-  
+
   return ret;
 }
-    
-std::vector<RegisterType> Options::GetRegisters(int board){
+
+std::vector<RegisterType> Options::GetRegisters(int board, bool strict){
   std::vector<RegisterType> ret;
-  
+  int ibid = 0;
+  std::string sdet = "";
   bsoncxx::array::view regarr = bson_options["registers"].get_array().value;
   for(bsoncxx::array::element ele : regarr){
-    if(board != ele["board"].get_int32() && ele["board"].get_int32() != -1)
-      continue;
-    RegisterType rt;
-    rt.board = ele["board"].get_int32();
-    rt.reg = ele["reg"].get_utf8().value.to_string();
-    rt.val = ele["val"].get_utf8().value.to_string();
+    try{
+      ibid = ele["board"].get_int32();
+      sdet = "";
+    }catch(const std::exception& e){
+      try{
+        sdet = ele["board"].get_utf8().value.to_string();
+        ibid = -1;
+      }catch(const std::exception& ee){
+        throw std::exception("Invalid register: board is neither int nor string");
+      }
+    }
+    if ((ibid != board) && strict) continue;
+    if ((ibid == board) || (sdet == fDetector) || (sdet == "all")) {
+      RegisterType rt;
+      rt.reg = ele["reg"].get_utf8().value.to_string();
+      rt.val = ele["val"].get_utf8().value.to_string();
 
-    ret.push_back(rt);
+      ret.push_back(rt);
+    }
   }
   return ret;
 }
@@ -247,22 +257,17 @@ std::vector<u_int16_t> Options::GetThresholds(int board) {
 }
 
 int Options::GetCrateOpt(CrateOptions &ret){
-  // I think we can just hack the above getters to allow dot notation
-  // for a more robust solution to access subdocuments
-  try{
+  if ((ret.pulser_freq = GetNestedInt("V2718."+fDetector+".pulser_freq", -1)) == -1) {
     try{
-      ret.pulser_freq = float(bson_options["V2718"]["pulser_freq"].get_int32().value);
+      ret.pulser_freq = bson_options["V2718"][fDetector]["pulser_freq"].get_double().value;
     } catch(std::exception& e) {
-      ret.pulser_freq = bson_options["V2718"]["pulser_freq"].get_double().value;
+      ret.pulser_freq = 0;
     }
-    ret.s_in = float(bson_options["V2718"]["s_in"].get_int32().value);
-    ret.muon_veto = bson_options["V2718"]["muon_veto"].get_int32().value;
-    ret.neutron_veto = bson_options["V2718"]["neutron_veto"].get_int32().value;
-    ret.led_trigger = bson_options["V2718"]["led_trigger"].get_int32().value;
-  }catch(std::exception &E){
-    fLog->Entry(MongoLog::Local, "Exception getting ccontroller opts: %s", E.what());
-    return -1;
   }
+  ret.s_in = GetNestedInt("V2718."+fDetector+".s_in", 0);
+  ret.muon_veto = GetNestedInt("V2718."+fDetector+".muon_veto", 0);
+  ret.neutron_veto = GetNestedInt("V2718."+fDetector+".neutron_veto", 0);
+  ret.led_trigger = GetNestedInt("V2718."+fDetector+".led_trigger", 0);
   return 0;
 }
 
@@ -379,6 +384,7 @@ void Options::SaveBenchmarks(std::map<std::string, long>& byte_counter,
     std::map<int, long>& buffer_counter,
     double proc_time_dp_us, double proc_time_ev_us, double proc_time_ch_us, double comp_time_us) {
   using namespace bsoncxx::builder::stream;
+  if (GetInt("benchmark_level", 1) == 0) return;
   int run_id = -1;
   try{
     run_id = std::stoi(GetString("run_identifier", "latest"));
@@ -397,11 +403,13 @@ void Options::SaveBenchmarks(std::map<std::string, long>& byte_counter,
   update_doc << "processing_time_ev_us" << proc_time_ev_us;
   update_doc << "processing_time_ch_us" << proc_time_ch_us;
   update_doc << "compression_time_us" << comp_time_us;
-  update_doc << "buffer_xfers" << open_document;
-  for (auto& p : buffer_counter) {
-    update_doc << std::to_string(p.first) << p.second;
+  if (GetInt("benchmark_level", 1) == 2) {
+    update_doc << "buffer_xfers" << open_document;
+    for (auto& p : buffer_counter) {
+      update_doc << std::to_string(p.first) << p.second;
+    }
+    update_doc << close_document; // buffer xfers
   }
-  update_doc << close_document; // buffer xfers
 
   update_doc << close_document; // push
   auto write_doc = update_doc << finalize;

--- a/Options.hh
+++ b/Options.hh
@@ -19,14 +19,11 @@ struct BoardType{
   std::string type;
   std::string host;
   unsigned int vme_address;
-
 };
 
 struct RegisterType{
-  int board;
   std::string reg;
   std::string val;
-
 };
 
 struct CrateOptions{
@@ -63,31 +60,28 @@ class MongoLog;
 class Options{
 
 public:
-  Options(MongoLog *log, std::string name, std::string hostname, std::string suri,
-  	std::string dbname, std::string override_opts);
+  Options(MongoLog*, std::string, std::string, std::string, std::string, std::string);
   ~Options();
 
-  int Load(std::string name, mongocxx::collection& opts_collection, std::string override_opts);
-  int Override(bsoncxx::document::view override_opts);
-  std::string ExportToString();
-  
-  int GetInt(std::string key, int default_value=-1);
-  long int GetLongInt(std::string key, long int default_value=-1);
-  double GetDouble(std::string key, double default_value=-1);
-  std::string GetString(std::string key, std::string default_value="");
+  int GetInt(std::string, int=-1);
+  long int GetLongInt(std::string, long int=-1);
+  double GetDouble(std::string, double=-1);
+  std::string GetString(std::string, std::string="");
 
-  std::vector<BoardType> GetBoards(std::string type="", std::string hostname="DEFAULT");
-  std::vector<RegisterType> GetRegisters(int board=-1);
-  int GetDAC(std::map<int, std::map<std::string, std::vector<double>>>& board_dacs, std::vector<int>& bids);
+  std::vector<BoardType> GetBoards(std::string);
+  std::vector<RegisterType> GetRegisters(int, bool=false);
+  int GetDAC(std::map<int, std::map<std::string, std::vector<double>>>&, std::vector<int>&);
   int GetCrateOpt(CrateOptions &ret);
   int GetHEVOpt(HEVOptions &ret);
-  int16_t GetChannel(int bid, int cid);
-  int GetNestedInt(std::string path, int default_value);
-  std::vector<u_int16_t> GetThresholds(int board);
+  int16_t GetChannel(int, int);
+  int GetNestedInt(std::string, int);
+  std::vector<uint16_t> GetThresholds(int);
 
   void UpdateDAC(std::map<int, std::map<std::string, std::vector<double>>>&);
   void SaveBenchmarks(std::map<std::string, long>&, std::map<int, long>&, double, double, double, double);
 private:
+  int Load(std::string, mongocxx::collection&, std::string);
+  int Override(bsoncxx::document::view);
   mongocxx::client fClient;
   bsoncxx::document::view bson_options;
   bsoncxx::document::value *bson_value;
@@ -95,6 +89,7 @@ private:
   mongocxx::collection fDAC_collection;
   std::string fDBname;
   std::string fHostname;
+  std::string fDetector;
 };
 
 #endif

--- a/StraxInserter.cc
+++ b/StraxInserter.cc
@@ -69,7 +69,7 @@ StraxInserter::~StraxInserter(){
   }
   long total_dps = std::accumulate(fBufferCounter.begin(), fBufferCounter.end(), 0,
       [&](long tot, auto& p){return std::move(tot) + p.second;});
-  fLog->Entry(MongoLog::Local, "Thread %lx got events %.1f\% of the time",
+  fLog->Entry(MongoLog::Local, "Thread %lx got events %.1f%% of the time",
       fThreadId, (total_dps-fBufferCounter[0]+0.0)/total_dps*100.);
   std::map<std::string, long> counters {
     {"bytes", fBytesProcessed},

--- a/StraxInserter.cc
+++ b/StraxInserter.cc
@@ -597,5 +597,4 @@ data_packet::~data_packet() {
   if (buff != nullptr) delete[] buff;
   buff = nullptr;
   size = clock_counter = header_time = bid = 0;
-  //vBLT.clear();
 }

--- a/StraxInserter.cc
+++ b/StraxInserter.cc
@@ -68,7 +68,9 @@ StraxInserter::~StraxInserter(){
     std::this_thread::sleep_for(std::chrono::seconds(2));
   }
   long total_dps = std::accumulate(fBufferCounter.begin(), fBufferCounter.end(), 0,
-      [&](long tot, auto& p){return tot + p.second;});
+      [&](long tot, auto& p){return std::move(tot) + p.second;});
+  fLog->Entry(MongoLog::Local, "Thread %lx got events %.1f\% of the time",
+      fThreadId, (total_dps-fBufferCounter[0]+0.0)/total_dps*100.);
   std::map<std::string, long> counters {
     {"bytes", fBytesProcessed},
     {"fragments", fFragmentsProcessed},
@@ -400,6 +402,7 @@ int StraxInserter::ReadAndInsertData(){
         b.clear();
         WriteOutFiles();
       } else {
+        fBufferCounter[0]++;
         std::this_thread::sleep_for(sleep_time);
       }
     }

--- a/StraxInserter.hh
+++ b/StraxInserter.hh
@@ -29,7 +29,6 @@ struct data_packet{
     u_int32_t clock_counter;
     u_int32_t header_time;
     int bid;
-    std::vector<u_int32_t> vBLT;
 };
 
 

--- a/V1495.cc
+++ b/V1495.cc
@@ -30,7 +30,7 @@ int V1495::WriteReg(unsigned int reg, unsigned int value){
 				fBID, reg, value, fBoardHandle);
 		return -1;
 	}
-	fLog->Entry(MongoLog::Message, "V1495: %i written register 0x%04x with value %08x (handle %i)",
+	fLog->Entry(MongoLog::Local, "V1495: %i written register 0x%04x with value %08x (handle %i)",
 			fBID, reg, value, fBoardHandle);
 	return 0;
 }

--- a/V1724.cc
+++ b/V1724.cc
@@ -286,7 +286,7 @@ unsigned int V1724::ReadRegister(unsigned int reg){
   return temp;
 }
 
-int V1724::ReadMBLT(u_int32_t* &buffer, std::vector<unsigned int>* v){
+int V1724::ReadMBLT(u_int32_t* &buffer){
   // Initialize
   int64_t blt_bytes=0;
   int nb=0,ret=-5;
@@ -295,11 +295,13 @@ int V1724::ReadMBLT(u_int32_t* &buffer, std::vector<unsigned int>* v){
   int count = 0;
   int alloc_size = BLT_SIZE/sizeof(u_int32_t)*fBLTSafety;
   u_int32_t* thisBLT = nullptr;
+  if (GetAcquisitionStatus() & 0x8 == 0) return 0;
+  // digitizer has at least one event
   do{
 
     // Reserve space for this block transfer
     thisBLT = new u_int32_t[alloc_size];
-    
+
     try{
       ret = CAENVME_FIFOBLTReadCycle(fBoardHandle, fBaseAddress,
 				     ((unsigned char*)thisBLT),
@@ -347,7 +349,6 @@ int V1724::ReadMBLT(u_int32_t* &buffer, std::vector<unsigned int>* v){
     for (auto& xfer : xfer_buffers) {
       std::memcpy(((unsigned char*)buffer)+bytes_copied, xfer.first, xfer.second);
       bytes_copied += xfer.second;
-      if (v != nullptr) v->push_back(xfer.second);
     }
     fBLTCounter[count]++;
     if (bytes_copied != blt_bytes) fLog->Entry(MongoLog::Message,

--- a/V1724.cc
+++ b/V1724.cc
@@ -295,7 +295,7 @@ int V1724::ReadMBLT(u_int32_t* &buffer){
   int count = 0;
   int alloc_size = BLT_SIZE/sizeof(u_int32_t)*fBLTSafety;
   u_int32_t* thisBLT = nullptr;
-  if (GetAcquisitionStatus() & 0x8 == 0) return 0;
+  if ((GetAcquisitionStatus() & 0x8) == 0) return 0;
   // digitizer has at least one event
   do{
 

--- a/V1724.cc
+++ b/V1724.cc
@@ -302,17 +302,9 @@ int V1724::ReadMBLT(u_int32_t* &buffer){
     // Reserve space for this block transfer
     thisBLT = new u_int32_t[alloc_size];
 
-    try{
-      ret = CAENVME_FIFOBLTReadCycle(fBoardHandle, fBaseAddress,
+    ret = CAENVME_FIFOBLTReadCycle(fBoardHandle, fBaseAddress,
 				     ((unsigned char*)thisBLT),
 				     BLT_SIZE, cvA32_U_MBLT, cvD64, &nb);
-    }catch(std::exception E){
-      std::cout<<fBoardHandle<<" sucks"<<std::endl;
-      std::cout<<"BLT_BYTES: "<<blt_bytes<<std::endl;
-      std::cout<<"nb: "<<nb<<std::endl;
-      std::cout<<E.what()<<std::endl;
-      throw;
-    };
     if( (ret != cvSuccess) && (ret != cvBusError) ){
       fLog->Entry(MongoLog::Error,
 		  "Board %i read error after %i reads: (%i) and transferred %i bytes this read",
@@ -320,7 +312,7 @@ int V1724::ReadMBLT(u_int32_t* &buffer){
 
       // Delete all reserved data and fail
       delete[] thisBLT;
-      for (auto b : xfer_buffers) delete[] b.first;
+      for (auto& b : xfer_buffers) delete[] b.first;
       return -1;
     }
     if (nb > (int)BLT_SIZE) fLog->Entry(MongoLog::Message,

--- a/V1724.hh
+++ b/V1724.hh
@@ -16,7 +16,7 @@ class V1724{
   virtual ~V1724();
 
   int Init(int link, int crate, int bid, unsigned int address=0);
-  int ReadMBLT(u_int32_t* &buffer, std::vector<unsigned int>* v=nullptr);
+  int ReadMBLT(u_int32_t* &buffer);
   int WriteRegister(unsigned int reg, unsigned int value);
   unsigned int ReadRegister(unsigned int reg);
   int GetClockCounter(u_int32_t timestamp, u_int32_t this_event_num);

--- a/V2718.cc
+++ b/V2718.cc
@@ -33,21 +33,16 @@ int V2718::SendStartSignal(){
 
   // Straight copy from: https://github.com/coderdj/kodiaq
 
-  // Line 0 : S-IN. 
-  CAENVME_SetOutputConf(fCrate, cvOutput0, cvDirect, 
-			cvActiveHigh, cvManualSW);
+  // Line 0 : S-IN.
+  CAENVME_SetOutputConf(fCrate, cvOutput0, cvDirect, cvActiveHigh, cvManualSW);
   // Line 1 : MV S-IN Logic
-  CAENVME_SetOutputConf(fCrate, cvOutput1, cvDirect, 
-			cvActiveHigh, cvManualSW);
+  CAENVME_SetOutputConf(fCrate, cvOutput1, cvDirect, cvActiveHigh, cvManualSW);
   // Line 2 : LED Logic
-  CAENVME_SetOutputConf(fCrate, cvOutput2, cvDirect, 
-			cvActiveHigh, cvManualSW);
+  CAENVME_SetOutputConf(fCrate, cvOutput2, cvDirect, cvActiveHigh, cvManualSW);
   // Line 3 : LED Pulser
-  CAENVME_SetOutputConf(fCrate, cvOutput3, cvDirect, 
-			cvActiveHigh, cvMiscSignals);
-  // Line 4 : NV S-IN Logic   
-  CAENVME_SetOutputConf(fCrate, cvOutput4, cvDirect,
-                        cvActiveHigh, cvMiscSignals); // soonTM
+  CAENVME_SetOutputConf(fCrate, cvOutput3, cvDirect, cvActiveHigh, cvMiscSignals);
+  // Line 4 : NV S-IN Logic
+  CAENVME_SetOutputConf(fCrate, cvOutput4, cvDirect, cvActiveHigh, cvMiscSignals); // soonTM
 
 
   // Set the output register
@@ -93,8 +88,8 @@ int V2718::SendStartSignal(){
     }
     // Set pulser
     int ret = CAENVME_SetPulserConf(fCrate, cvPulserB, period, width, tu, 0,
-	 		  cvManualSW, cvManualSW);
-    ret *= CAENVME_StartPulser(fCrate,cvPulserB); 
+                                    cvManualSW, cvManualSW);
+    ret *= CAENVME_StartPulser(fCrate,cvPulserB);
     if(ret != cvSuccess){
       fLog->Entry(MongoLog::Warning, "Failed to activate LED pulser");
       return -1;
@@ -115,7 +110,7 @@ int V2718::SendStopSignal(bool end){
 
   // Line 0 : S-IN.
   CAENVME_SetOutputConf(fCrate, cvOutput0, cvDirect, cvActiveHigh, cvManualSW);
-  // Line 1 : MV S-IN Logic 
+  // Line 1 : MV S-IN Logic
   CAENVME_SetOutputConf(fCrate, cvOutput1, cvDirect, cvActiveHigh, cvManualSW);
   // Line 2 : LED Logic
   CAENVME_SetOutputConf(fCrate, cvOutput2, cvDirect, cvActiveHigh, cvManualSW);
@@ -123,10 +118,10 @@ int V2718::SendStopSignal(bool end){
   CAENVME_SetOutputConf(fCrate, cvOutput3, cvDirect, cvActiveHigh, cvMiscSignals);
   // Line 4 : NV S-IN Logic
   CAENVME_SetOutputConf(fCrate, cvOutput4, cvDirect, cvActiveHigh, cvManualSW);
-  
 
-  // Set the output register 
-  unsigned int data = 0x0; 
+
+  // Set the output register
+  unsigned int data = 0x0;
   CAENVME_SetOutputRegister(fCrate,data);
 
   if(end){


### PR DESCRIPTION
Some changes to allow redax to function in combined operation modes. This is accomplished with a few minor changes:
- the Options class keeps track of which detector it is instanced for via a `detectors` subdocument in the config.
- Registers no longer take `-1` as the board-agnostic id. There are now two new levels of board agnosticism: registers labelled as `all` are issued to _all_ boards, registers labelled as (for instance) `tpc` are issued to all boards on hosts registered to service that detector.

Some cleanup in function calls and unnecessary whitespace is also included, along with a minor change with potentially significant performance savings: when reading data from digitizers, rather than allocating memory before finding out that the board has no data, it now checks to see if the board has at least one event before allocating readout space.

Also, the storing of benchmarks has been adjusted. Each thread's data is stored in a list of objects rather than separate lists. At `benchmark_level==2`, the buffer transfer data is log-rebinned, and at `benchmark_level==3` it is stored without reduction. `benchmark_level==0` means no storage of benchmarks, `benchmark_level==1` means timing information and simple counters.