### PR TITLE
Replaces convoluted self-built configs with an aggregation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ log_*
 
 # python caches
 *__pycache__*
+*strax_data*

--- a/DAQController.cc
+++ b/DAQController.cc
@@ -184,6 +184,7 @@ int DAQController::Stop(){
   fStatus = DAXHelpers::Idle;
 
   fLog->SetRunId(-1);
+  fOptions.reset();
   std::cout<<"Finished end"<<std::endl;
   fStatus = DAXHelpers::Idle;
   return 0;

--- a/MongoLog.cc
+++ b/MongoLog.cc
@@ -1,32 +1,24 @@
 #include "MongoLog.hh"
 #include <iostream>
 #include <chrono>
-#include <mongocxx/uri.hpp>
-#include <mongocxx/database.hpp>
 #include <bsoncxx/builder/stream/document.hpp>
 
-MongoLog::MongoLog(int DeleteAfterDays, std::string log_dir, std::string connection_uri,
-    std::string db, std::string collection, std::string host){
+MongoLog::MongoLog(int DeleteAfterDays, std::shared_ptr<mongocxx::pool>& pool, std::string dbname, std::string log_dir, std::string host) : 
+  fPool(pool), fClient(pool->acquire()) {
   fLogLevel = 0;
   fHostname = host;
   fDeleteAfterDays = DeleteAfterDays;
   fFlushPeriod = 5; // seconds
   fOutputDir = log_dir;
+  //fPool = pool;
+  //fClient = pool->acquire();
+  fDB = (*fClient)[dbname];
+  fCollection = fDB["log"];
 
   std::cout<<"Configured WITH local file logging to " << log_dir << std::endl;
   fFlush = true;
   fFlushThread = std::thread(&MongoLog::Flusher, this);
   fRunId = -1;
-
-  try{
-    mongocxx::uri uri{connection_uri};
-    fMongoClient = mongocxx::client(uri);
-    fMongoCollection = fMongoClient[db][collection];
-  }
-  catch(const std::exception &e){
-    std::cout<<"Couldn't initialize the log. So gonna fail then."<<std::endl;
-    throw std::runtime_error("Couldn't initialize the log");
-  }
 
   RotateLogFile();
 
@@ -127,7 +119,7 @@ int MongoLog::Entry(int priority, std::string message, ...){
         "priority" << priority <<
         "runid" << fRunId <<
         bsoncxx::builder::stream::finalize;
-      fMongoCollection.insert_one(std::move(d));
+      fCollection.insert_one(std::move(d));
     }
     catch(const std::exception &e){
       std::cout<<"Failed to insert log message "<<message<<" ("<<

--- a/MongoLog.hh
+++ b/MongoLog.hh
@@ -14,8 +14,11 @@
 #include <atomic>
 #include <thread>
 #include <experimental/filesystem>
+#include <memory>
 
+#include <mongocxx/pool.hpp>
 #include <mongocxx/client.hpp>
+#include <mongocxx/database.hpp>
 #include <mongocxx/collection.hpp>
 
 /* 
@@ -53,7 +56,7 @@ class MongoLog{
   */
 
 public:
-  MongoLog(int DeleteAfterDays, std::string log_dir, std::string, std::string, std::string, std::string);
+  MongoLog(int DeleteAfterDays, std::shared_ptr<mongocxx::pool>&, std::string, std::string, std::string);
   ~MongoLog();
   
   int  Initialize(std::string connection_string,
@@ -76,11 +79,13 @@ private:
   int Today(struct tm* date);
   int RotateLogFile();
   std::string LogFileName(struct tm* date);
+  std::shared_ptr<mongocxx::pool> fPool;
+  mongocxx::pool::entry fClient;
+  mongocxx::database fDB;
+  mongocxx::collection fCollection;
   std::vector<std::string> fPriorities{"LOCAL", "DEBUG", "MESSAGE",
       "WARNING", "ERROR", "FATAL"};
   std::ofstream fOutfile;
-  mongocxx::client fMongoClient;
-  mongocxx::collection fMongoCollection;
   std::string fHostname;
   int fLogLevel;
   int fDeleteAfterDays;

--- a/Options.cc
+++ b/Options.cc
@@ -30,8 +30,7 @@ Options::~Options(){
   }
 }
 
-int Options::Load(std::string name, mongocxx::collection* opts_collection,
-    std::string override_opts) {
+int Options::Load(std::string name, mongocxx::collection* opts_collection, std::string override_opts) {
   using namespace bsoncxx::builder::stream;
   auto pl = mongocxx::pipeline();
   pl.match(document{} << "name" << name << finalize);

--- a/Options.cc
+++ b/Options.cc
@@ -46,7 +46,7 @@ int Options::Load(std::string name, mongocxx::collection* opts_collection, std::
   pl.project(document{} << "subconfig" << 0 << finalize);
   if (override_opts != "")
     pl.add_fields(bsoncxx::from_json(override_opts));
-  for (auto doc : opts_collection.aggregate(pl)) {
+  for (auto doc : opts_collection->aggregate(pl)) {
     bson_value = new bsoncxx::document::value(doc);
     bson_options = bson_value->view();
     try{

--- a/Options.hh
+++ b/Options.hh
@@ -7,10 +7,13 @@
 #include <streambuf>
 #include <iostream>
 #include <stdexcept>
+#include <memory>
+#include <mongocxx/pool.hpp>
+#include <mongocxx/client.hpp>
+#include <mongocxx/database.hpp>
+#include <mongocxx/collection.hpp>
 #include <bsoncxx/document/view.hpp>
 #include <bsoncxx/document/value.hpp>
-#include <mongocxx/collection.hpp>
-#include <mongocxx/client.hpp>
 
 struct BoardType{
   int link;
@@ -67,7 +70,7 @@ class MongoLog;
 class Options{
 
 public:
-  Options(std::shared_ptr<MongoLog>&, std::string, std::string, std::string, std::string, std::string);
+  Options(std::shared_ptr<MongoLog>&, std::string, std::string, mongocxx::collection*, std::shared_ptr<mongocxx::pool>&, std::string, std::string);
   ~Options();
 
   int GetInt(std::string, int=-1);
@@ -87,20 +90,19 @@ public:
   int GetFaxOptions(fax_options_t&);
 
   void UpdateDAC(std::map<int, std::vector<uint16_t>>&);
-  void SaveBenchmarks(std::map<std::string, std::map<int, long>>&, long, std::string,
-      std::map<std::string, double>&);
 
 private:
-  int Load(std::string, mongocxx::collection&, std::string);
+  int Load(std::string, mongocxx::collection*, std::string);
   int Override(bsoncxx::document::view);
-  mongocxx::client fClient;
   bsoncxx::document::view bson_options;
   bsoncxx::document::value *bson_value;
   std::shared_ptr<MongoLog> fLog;
-  mongocxx::collection fDAC_collection;
-  std::string fDBname;
   std::string fHostname;
   std::string fDetector;
+  std::shared_ptr<mongocxx::pool> fPool;
+  mongocxx::pool::entry fClient; // yes
+  mongocxx::database fDB;
+  mongocxx::collection fDAC_collection;
 };
 
 #endif

--- a/Options.hh
+++ b/Options.hh
@@ -93,7 +93,6 @@ public:
 
 private:
   int Load(std::string, mongocxx::collection*, std::string);
-  int Override(bsoncxx::document::view);
   bsoncxx::document::view bson_options;
   bsoncxx::document::value *bson_value;
   std::shared_ptr<MongoLog> fLog;

--- a/StraxFormatter.cc
+++ b/StraxFormatter.cc
@@ -79,7 +79,7 @@ StraxFormatter::~StraxFormatter(){
     {"data_packets", fBufferCounter},
     {"chunks", fBytesPerChunk}
   };
-  fOptions->SaveBenchmarks(counters, fBytesProcessed, ss.str(), times);
+  //fOptions->SaveBenchmarks(counters, fBytesProcessed, ss.str(), times);
 }
 
 void StraxFormatter::Close(std::map<int,int>& ret){
@@ -302,7 +302,7 @@ void StraxFormatter::Process() {
       fBuffer.pop_front();
       lk.unlock();
       ProcessDatapacket(std::move(dp));
-      WriteOutChunks();
+      if (fActive == true) WriteOutChunks();
     } else {
       lk.unlock();
     }

--- a/dispatcher/MongoConnect.py
+++ b/dispatcher/MongoConnect.py
@@ -325,7 +325,7 @@ class MongoConnect():
                 {'$lookup': {'from': 'options', 'localField': 'includes',
                     'foreignField': 'name', 'as': 'subconfig'}},
                 {'$addFields': {'subconfig': {'$concatArrays': ['$subconfig', ['$$ROOT']]}}},
-                {'$unwind': {'path': '$subconfig'}},
+                {'$unwind': '$subconfig'},
                 {'$group': {'_id': None, 'config': {'$mergeObjects': '$subconfig'}}},
                 {'$replaceWith': '$config'},
                 {'$project': {'_id': 0, 'description': 0, 'includes': 0, 'subconfig': 0}},

--- a/dispatcher/MongoConnect.py
+++ b/dispatcher/MongoConnect.py
@@ -309,11 +309,11 @@ class MongoConnect():
         '''
         if mode is None:
             return None
-        base_doc = self.collections['options'].find_one({'name': mode}, {'includes': 1})
+        base_doc = self.collections['options'].find_one({'name': mode})
         if base_doc is None:
             self.LogError("dispatcher", "Mode '%s' doesn't exist" % mode, "info", "info")
             return None
-        if 'includes' not in base_doc:
+        if 'includes' not in base_doc or len(base_doc['includes']) == 0:
             return base_doc
         try:
             if self.collections['options'].count_documents({'name':

--- a/dispatcher/MongoConnect.py
+++ b/dispatcher/MongoConnect.py
@@ -318,7 +318,7 @@ class MongoConnect():
         try:
             if self.collections['options'].count_documents({'name':
                 {'$in': base_doc['includes']}}) != len(base_doc['includes']):
-                self.LogError("dispatcher", "At least one subconfig for mode '%s' doesn't exist" % mode, "warn", "warn"):
+                self.LogError("dispatcher", "At least one subconfig for mode '%s' doesn't exist" % mode, "warn", "warn")
                 return None
             return list(self.collections["options"].aggregate([
                 {'$match': {'name': mode}},

--- a/docs/databases.md
+++ b/docs/databases.md
@@ -122,7 +122,7 @@ The control database is used to propagate commands from the dispatcher to the re
      "user" : "web",
      "host" : ["fdaq00_reader_0"],
      "acknowledged" : {
-         "fdaq00_reader_0" : 1601469970934
+         "fdaq00_reader_0" : 0
      },
      "command" : "arm",
      "createdAt": <date object>
@@ -135,7 +135,7 @@ The control database is used to propagate commands from the dispatcher to the re
 |mode	|Options file to use for this run. Corresponds to the 'name' field of the options doc. |
 |user	|Who started the run? Corresponds to the last person to change the detector_status doc during normal operation. Exceptional stop commands can be automatically issued by various subsystems as well in case of errors.
 |host	|List of all hosts to which this command is directed. Readers and crate controllers will only process commands addressed to them. |
-|acknowledged	|Before attempting to process a command all reader and crate controller processes will first acknowledge the command as received. This does not indicate that processing the command was successful! It just indicates the thing tried. The dispatcher has to watch for the appropriate state change of the slave nodes in order to determine if the command achieved its goal. This is a dictionary, with values set to the timestamp (in ms) of when the acknowledgement happened. |
+|acknowledged	|Before attempting to process a command all reader and crate controller processes will first acknowledge the command as received. This does not indicate that processing the command was successful! It just indicates the thing tried. The dispatcher has to watch for the appropriate state change of the slave nodes in order to determine if the command achieved its goal. This is a dictionary, with values set to the timestamp of when the acknowledgement happened. This dictionary must be populated with 0s before insertion. |
 |command	|This is the actual command. 'arm' gets the DAQ ready to start. 'start' and 'stop' do what they say on the tin. 'stop' can also be used as a general reset command for a given instance. |
 
 ### db.options

--- a/helpers/runcommand.py
+++ b/helpers/runcommand.py
@@ -12,6 +12,8 @@ def main(coll):
     parser.add_argument('--host', nargs='+', default=[os.uname()[1]], help="Hosts to issue to")
 
     args = parser.parse_args()
+    if not isinstance(args.host, (list, tuple)):
+        args.host = [args.host]
 
     doc = {
             "command": args.command,
@@ -20,13 +22,14 @@ def main(coll):
             "host": args.host,
             "user": os.getlogin(),
             "run_identifier": '%06i' % args.number,
-            "createdAt": datetime.datetime.utcnow()
+            "createdAt": datetime.datetime.utcnow(),
+            "acknowledged": {h:0 for h in args.host}
             }
     coll.insert_one(doc)
     return
 
 if __name__ == '__main__':
-    with MongoClient("mongodb://daq:%s@xenon1t-daq:27017/admin" % os.environ['MONGO_PASSWORD_DAQ']) as client:
+    with MongoClient("mongodb://daq:%s@gw:27020/admin" % os.environ['MONGO_PASSWORD_DAQ']) as client:
         try:
             main(client['daq']['control'])
         except Exception as e:

--- a/main.cc
+++ b/main.cc
@@ -15,6 +15,10 @@
 #include <mongocxx/instance.hpp>
 #include <bsoncxx/builder/stream/document.hpp>
 #include <bsoncxx/json.hpp>
+#include <mongocxx/uri.hpp>
+#include <mongocxx/database.hpp>
+#include <mongocxx/client.hpp>
+#include <mongocxx/pool.hpp>
 
 std::atomic_bool b_run = true;
 std::string hostname = "";
@@ -25,32 +29,35 @@ void SignalHandler(int signum) {
     return;
 }
 
-void UpdateStatus(std::string suri, std::string dbname, std::unique_ptr<DAQController>& controller) {
-  mongocxx::uri uri(suri);
-  mongocxx::client c(uri);
-  mongocxx::collection status = c[dbname]["status"];
+void UpdateStatus(std::shared_ptr<mongocxx::pool> pool, std::string dbname,
+    std::unique_ptr<DAQController>& controller) {
   using namespace std::chrono;
+  auto client = pool->acquire();
+  auto db = (*client)[dbname];
+  auto collection = db["status"];
   while (b_run == true) {
+    auto start = std::chrono::system_clock::now();
     try{
-      controller->StatusUpdate(&status);
+      controller->StatusUpdate(&collection);
     }catch(const std::exception &e){
       std::cout<<"Can't connect to DB to update."<<std::endl;
       std::cout<<e.what()<<std::endl;
     }
-    std::this_thread::sleep_for(seconds(1));
+    auto end = std::chrono::system_clock::now();
+    std::this_thread::sleep_for(seconds(1)-(end-start));
   }
   std::cout<<"Status update returning\n";
 }
 
 int PrintUsage() {
-  std::cout<<"Welcome to REDAX readout\nAccepted command-line arguments:\n"
+  std::cout<<"Welcome to REDAX\nAccepted command-line arguments:\n"
     << "--id <id number>: id number of this readout instance, required\n"
     << "--uri <mongo uri>: full MongoDB URI, required\n"
     << "--db <database name>: name of the database to use, default \"daq\"\n"
     << "--logdir <directory>: where to write the logs, default pwd\n"
     << "--reader: this instance is a reader\n"
     << "--cc: this instance is a crate controller\n"
-    << "--arm-delay <delay>: ms to wait between the ARM command and the arming sequence, default 15000\n"
+    << "--arm-delay <delay>: ms to wait between the ARM command and the arming sequence, default 5000\n"
     << "--log-retention <value>: how many days to keep logfiles, default 7\n"
     << "--help: print this message\n"
     << "\n";
@@ -122,15 +129,14 @@ int main(int argc, char** argv){
   // MongoDB Connectivity for control database. Bonus for later:
   // exception wrap the URI parsing and client connection steps
   mongocxx::uri uri(suri.c_str());
-  mongocxx::client client(uri);
-  mongocxx::database db = client[dbname];
+  auto pool = std::make_shared<mongocxx::pool>(uri);
+  auto client = pool->acquire();
+  mongocxx::database db = (*client)[dbname];
   mongocxx::collection control = db["control"];
-  mongocxx::collection status = db["status"];
-  mongocxx::collection options_collection = db["options"];
-  mongocxx::collection dac_collection = db["dac_calibration"];
+  mongocxx::collection opts_collection = db["options"];
 
   // Logging
-  auto fLog = std::make_shared<MongoLog>(log_retention, log_dir, suri, dbname, "log", hostname);
+  auto fLog = std::make_shared<MongoLog>(log_retention, pool, dbname, log_dir, hostname);
 
   //Options
   std::shared_ptr<Options> fOptions;
@@ -142,16 +148,16 @@ int main(int argc, char** argv){
     controller = std::make_unique<CControl_Handler>(fLog, hostname);
   else
     controller = std::make_unique<DAQController>(fLog, hostname);
-  std::thread status_update(&UpdateStatus, suri, dbname, std::ref(controller));
+  std::thread status_update(&UpdateStatus, pool, dbname, std::ref(controller));
 
   using namespace bsoncxx::builder::stream;
   // Sort oldest to newest
   auto opts = mongocxx::options::find_one_and_update{};
   opts.sort(document{} << "_id" << 1 << finalize);
-  auto query = document{} << "host" << hostname << "acknowledged." + hostname <<
-    open_document << "$exists" << 0 << close_document << finalize;
+  std::string ack_host = "acknowledged." + hostname;
+  auto query = document{} << "host" << hostname << ack_host << 0 << finalize;
   auto update = document{} << "$currentDate" << open_document <<
-    "acknowledged."+hostname << true << close_document << finalize;
+    ack_host << true << close_document << finalize;
   using namespace std::chrono;
   // Main program loop. Scan the database and look for commands addressed
   // to this hostname. 
@@ -196,6 +202,7 @@ int main(int argc, char** argv){
           fLog->Entry(MongoLog::Local, "Ack to stop took %i us",
               duration_cast<microseconds>(now-ack_time).count());
           fLog->SetRunId(-1);
+          fOptions.reset();
 	} else if(command == "arm"){
 	  // Can only arm if we're idle
 	  if(controller->status() == 0){
@@ -212,8 +219,8 @@ int main(int argc, char** argv){
 	    // Mongocxx types confusing so passing json strings around
             std::string mode = doc["mode"].get_utf8().value.to_string();
             fLog->Entry(MongoLog::Local, "Getting options doc for mode %s", mode.c_str());
-	    fOptions = std::make_shared<Options>(fLog, mode,
-				   hostname, suri, dbname, override_json);
+	    fOptions = std::make_shared<Options>(fLog, mode, hostname, &opts_collection,
+			      pool, dbname, override_json);
             int dt = duration_cast<milliseconds>(system_clock::now()-ack_time).count();
             fLog->SetRunId(fOptions->GetInt("number", -1));
             fLog->Entry(MongoLog::Local, "Took %i ms to load config", dt);


### PR DESCRIPTION
The mongocxx method for combining documents is truly terrible. A much nicer way of doing this is via an aggregate that lets Mongo itself handle combining things.  Also, the dispatcher now checks to make sure that all the `includes` exist before proceeding, logging a warning message if not. This fixes #104.