### PR TITLE
V1495 subclass options

### DIFF
--- a/CControl_Handler.cc
+++ b/CControl_Handler.cc
@@ -5,6 +5,7 @@
 #include "DDC10.hh"
 #endif
 #include "V1495.hh"
+#include "V1495_tpc.hh"
 #include <bsoncxx/builder/stream/document.hpp>
 
 CControl_Handler::CControl_Handler(std::shared_ptr<MongoLog>& log, std::string procname) : DAQController(log, procname){
@@ -85,21 +86,31 @@ int CControl_Handler::Arm(std::shared_ptr<Options>& opts){
   }
 #endif // HASDDC10
 
-  std::vector<BoardType> mv = fOptions->GetBoards("V1495");
-  if (mv.size() == 1){
-    BoardType mv_def = mv[0];
-    fBID = mv_def.board;
-    fV1495 = std::make_unique<V1495>(fLog, fOptions, mv_def.board, fBoardHandle, mv_def.vme_address);
-	// Writing registers to the V1495 board
-	for(auto regi : fOptions->GetRegisters(fBID, true)){
-		unsigned int reg = DAXHelpers::StringToHex(regi.reg);
-		unsigned int val = DAXHelpers::StringToHex(regi.val);
-		if(fV1495->WriteReg(reg, val)!=0){
-			fLog->Entry(MongoLog::Error, "Failed to initialise V1495 board");
-			fStatus = DAXHelpers::Idle;
-			return -1;
-		}
+  std::vector<BoardType> boards = fOptions->GetBoards("V1495");
+  if (boards.size() == 1){
+    BoardType v1495 = boards[0];
+    fBID = v1495.board;
+    if (v1495.detector == "tpc")
+      fV1495 = std::make_unique<V1495_TPC>(fLog, fOptions, fBID, fBoardHandle, v1495.vme_address);
+    else
+      fV1495 = std::make_unique<V1495>(fLog, fOptions, fBID, fBoardHandle, v1495.vme_address);
+
+    std::map<std::string, int> opts;
+    if (fOptions->GetV1495Opts(opts) < 0) {
+      fLog->Entry(MongoLog::Warning, "Error getting V1495 options");
+    } else if (fV1495->Arm(opts)) {
+      fLog->Entry(MongoLog::Warning, "Could not initialize V1495");
     }
+/*    // Writing registers to the V1495 board
+    for(auto regi : fOptions->GetRegisters(fBID, true)){
+      unsigned int reg = DAXHelpers::StringToHex(regi.reg);
+      unsigned int val = DAXHelpers::StringToHex(regi.val);
+      if(fV1495->WriteReg(reg, val)!=0){
+        fLog->Entry(MongoLog::Error, "Failed to initialise V1495 board");
+        fStatus = DAXHelpers::Idle;
+        return -1;
+      }
+    }*/
   }else{
   }
   fStatus = DAXHelpers::Armed;
@@ -112,8 +123,20 @@ int CControl_Handler::Start(){
     fLog->Entry(MongoLog::Warning, "V2718 attempt to start without arming. Maybe unclean shutdown");
     return 0;
   }
+  if(fV1495 && fV1495->BeforeSINStart()) {
+    fLog->Entry(MongoLog::Error, "Could not start V1495");
+    fStatus = DAXHelpers::Error;
+    return -1;
+  }
+
   if(!fV2718 || fV2718->SendStartSignal()!=0){
     fLog->Entry(MongoLog::Error, "V2718 either failed to start");
+    fStatus = DAXHelpers::Error;
+    return -1;
+  }
+
+  if(fV1495 && fV1495->AfterSINStart()) {
+    fLog->Entry(MongoLog::Error, "Could not start V1495");
     fStatus = DAXHelpers::Error;
     return -1;
   }
@@ -125,8 +148,14 @@ int CControl_Handler::Start(){
 // Stopping the previously started devices; V2718, V1495, DDC10...
 int CControl_Handler::Stop(){
   if(fV2718){
+    if (fV1495 && fV1495->BeforeSINStop()) {
+      fLog->Entry(MongoLog::Warning, "Could not stop V1495");
+    }
     if(fV2718->SendStopSignal() != 0){
       fLog->Entry(MongoLog::Warning, "Failed to stop V2718");
+    }
+    if (fV1495 && fV1495->AfterSINStop()) {
+      fLog->Entry(MongoLog::Warning, "Could not stop V1495");
     }
     fV2718.reset();
   }
@@ -166,47 +195,4 @@ void CControl_Handler::StatusUpdate(mongocxx::collection* collection){
   auto doc = after_array << finalize;
   collection->insert_one(std::move(doc));
   return;
-  /*
-  // DDC10 parameters might change for future updates of the XENONnT HEV
-  if(fDDC10){
-    auto hev_options = fDDC10->GetHEVOptions();
-    in_array << bsoncxx::builder::stream::open_document
-             << "type" << "DDC10"
-	     << "Address" << hev_options.address
-             << "required" << hev_options.required
-             << "signal_threshold" << hev_options.signal_threshold
-             << "sign" << hev_options.sign
-             << "rise_time_cut" << hev_options.rise_time_cut
-             << "inner_ring_factor" << hev_options.inner_ring_factor
-             << "outer_ring_factor" << hev_options.outer_ring_factor
-             << "integration_threshold" << hev_options.integration_threshold
-             << "parameter_0" << hev_options.parameter_0
-             << "parameter_1" << hev_options.parameter_1
-             << "parameter_2" << hev_options.parameter_2
-             << "parameter_3" << hev_options.parameter_3
-             << "window" << hev_options.window
-             << "prescaling" << hev_options.prescaling
-             << "component_status" << hev_options.component_status
-             << "width_cut" << hev_options.width_cut
-             << "delay" << hev_options.delay
-             << bsoncxx::builder::stream::close_document;
-  }
-  // Write the settings for the Muon Veto V1495 board into status doc 
-  if(fV1495){
-    auto registers = fOptions->GetRegisters(fBID);
-     in_array << bsoncxx::builder::stream::open_document
-	      << "type" << "V1495"
-	      << "Module reset" << registers[0].val
-	      << "Mask A" << registers[1].val
-	      << "Mask B" << registers[2].val
-	      << "Mask D" << registers[3].val
-	      << "Majority Threshold" << registers[4].val
-	      << "Coincidence Window" << registers[5].val
-	      << "NIM/TTL CTRL" << registers[6].val
-	      << bsoncxx::builder::stream::close_document; 
-  }
-  
-  after_array = in_array << bsoncxx::builder::stream::close_array;
-  return after_array << bsoncxx::builder::stream::finalize;
-*/
 }

--- a/Options.cc
+++ b/Options.cc
@@ -168,6 +168,11 @@ std::vector<BoardType> Options::GetBoards(std::string type){
     bt.crate = ele["crate"].get_int32();
     bt.board = ele["board"].get_int32();
     bt.type = ele["type"].get_utf8().value.to_string();
+    try {
+      bt.detector = ele["detector"].get_utf8().value.to_string();
+    } catch (const std::exception& e) {
+      bt.detector = "";
+    }
     bt.vme_address = DAXHelpers::StringToHex(ele["vme_address"].get_utf8().value.to_string());
     ret.push_back(bt);
   }
@@ -216,6 +221,18 @@ std::vector<u_int16_t> Options::GetThresholds(int board) {
     fLog->Entry(MongoLog::Local, "Using default thresholds for %i", board);
     return std::vector<u_int16_t>(16, default_threshold);
   }
+}
+
+int Options::GetV1495Opts(std::map<std::string, int>& ret) {
+  try {
+    for (auto& value : bson_options["V1495"][fDetector])
+      ret[value->key()] = value->get_int32().value;
+    return 0;
+  } catch (std::exception& e) {
+    fLog->Entry(MongoLog::Local, "Exception getting V1495 opts: %s", e.what());
+    return -1;
+  }
+  return 1;
 }
 
 int Options::GetCrateOpt(CrateOptions &ret){

--- a/Options.hh
+++ b/Options.hh
@@ -8,6 +8,7 @@
 #include <iostream>
 #include <stdexcept>
 #include <memory>
+#include <map>
 #include <mongocxx/pool.hpp>
 #include <mongocxx/client.hpp>
 #include <mongocxx/database.hpp>
@@ -22,6 +23,7 @@ struct BoardType{
   std::string type;
   std::string host;
   unsigned int vme_address;
+  std::string detector;
 };
 
 struct RegisterType{
@@ -82,6 +84,7 @@ public:
   std::vector<BoardType> GetBoards(std::string);
   std::vector<RegisterType> GetRegisters(int, bool=false);
   std::vector<uint16_t> GetDAC(int, int, uint16_t);
+  int GetV1495Opts(std::map<std::string, int>&);
   int GetCrateOpt(CrateOptions &ret);
   int GetHEVOpt(HEVOptions &ret);
   int16_t GetChannel(int, int);

--- a/V1495.cc
+++ b/V1495.cc
@@ -1,39 +1,30 @@
-// ** XENONnT Muon Veto V1495 Board **
-// Generic class for writing registers to a CAEN V1495 borad
-// Initialisation of the V1724 Muon Veto boards was moved to a dedeicated V1724_MV class
-
-#include <numeric>
-#include <iostream>
 #include "V1495.hh"
-#include "DAXHelpers.hh"
-#include "Options.hh"
 #include "MongoLog.hh"
+#include "Options.hh"
+#include <CAENVMElib.h>
 
 
 V1495::V1495(std::shared_ptr<MongoLog>& log, std::shared_ptr<Options>& options, int bid, int handle, unsigned int address){
-	fOptions = options;
-	fLog = log;
-	fBID = bid;
-	fBaseAddress = address;
-	fBoardHandle = handle;
+  fOptions = options;
+  fLog = log;
+  fBID = bid;
+  fBaseAddress = address;
+  fBoardHandle = handle;
 }
 
 V1495::~V1495(){}
 
-// Kept a separate write registers function for the V1495 here, but in principle can be derived from the V1724 class
 int V1495::WriteReg(unsigned int reg, unsigned int value){
-	u_int32_t write=0;
-	write+=value;
-	if(CAENVME_WriteCycle(fBoardHandle, fBaseAddress+reg,
-				&write,cvA32_U_DATA,cvD32) != cvSuccess){
-		fLog->Entry(MongoLog::Warning, "V1495: %i failed to write register 0x%04x with value %08x (handle %i)", 
-				fBID, reg, value, fBoardHandle);
-		return -1;
-	}
-	fLog->Entry(MongoLog::Local, "V1495: %i written register 0x%04x with value %08x (handle %i)",
-			fBID, reg, value, fBoardHandle);
-	return 0;
+  u_int32_t write=0;
+  write+=value;
+  if(CAENVME_WriteCycle(fBoardHandle, fBaseAddress+reg,
+        &write,cvA32_U_DATA,cvD32) != cvSuccess){
+    fLog->Entry(MongoLog::Warning, "V1495: %i failed to write register 0x%04x with value %08x (handle %i)", 
+        fBID, reg, value, fBoardHandle);
+    return -1;
+  }
+  fLog->Entry(MongoLog::Local, "V1495: %i written register 0x%04x with value %08x (handle %i)",
+      fBID, reg, value, fBoardHandle);
+  return 0;
 }
-
-
 

--- a/V1495.hh
+++ b/V1495.hh
@@ -1,10 +1,8 @@
 #ifndef _V1495_HH_
 #define _V1495_HH_
 
-#include <CAENVMElib.h>
-#include "MongoLog.hh"
-#include "Options.hh"
-#include "V1724.hh"
+#include <memory>
+#include <map>
 
 //Register address definitions taken from XENON1T m_veto class in kodiaq
 //https://github.com/coderdj/kodiaq and XENON1T DAQ m_veto config files
@@ -19,20 +17,26 @@
 #define V1495_CTRL			0x1018
 */
 
-using namespace std;
+class MongoLog;
+class Options;
 
 class V1495{
 
 public:
       V1495(std::shared_ptr<MongoLog>&, std::shared_ptr<Options>&, int, int, unsigned);
       virtual ~V1495();
-      int WriteReg(unsigned int reg, unsigned int value);
+      virtual int Init(std::map<std::string, int>&) {return 0;}
+      int WriteReg(unsigned int, unsigned int);
+      // Functions for a child class to implement
+      virtual int BeforeSINStart() {return 0;}
+      virtual int AfterSINStart() {return 0;}
+      virtual int BeforeSINStop() {return 0;}
+      virtual int AfterSINStop() {return 0;}
 
 private:
       int fBoardHandle, fBID;
       unsigned int fBaseAddress;
       std::shared_ptr<Options> fOptions;
       std::shared_ptr<MongoLog> fLog;
-
 };
 #endif

--- a/V1495_tpc.cc
+++ b/V1495_tpc.cc
@@ -1,0 +1,46 @@
+#include "V1495_tpc.hh"
+
+V1495_TPC::V1495_TPC(std::shared_ptr<MongoLog>& log, std::shared_ptr<Options>& opts, int bid, int handle, unsigned int address) :
+  V1495(log, opts, bid, handle, address), fControlReg(0x101E),
+  fVetoOffMSBReg(0x1012), fVetoOffLSBReg(0x1010),
+  fVetoOnMSBReg(0x100E), fVetoOnLSBReg(0x100C)
+{}
+
+V1495_TPC::~V1495_TPC() {}
+
+int V1495_TPC::Init(std::map<std::string, int>& opts) {
+  int clocks_per_us = 40;
+  if ((fFractionalModeActive = opts["fractional_mode_active"]) == 1) {
+    fVetoOn_clk = opts["veto_on_us"] * us_to_clock;
+    fVetoOff_clk = opts["veto_off_us"] * us_to_clock;
+    if (fVetoOn_clk * fVetoOff_clk == 0) {
+      fLog->Entry(MongoLog::Message, "V1495: at least one value is zero, check the config: %i/%i",
+          opts["veto_on_us"], opts["veto_off_us"]);
+      fFractionalModeActive = 0;
+    } else {
+      fLog->Entry(MongoLog::Local, "V1495 fractional mode active: %i/%i",
+          opts["veto_on_us"], opts["veto_off_us"]);
+    }
+  } else {
+    fLog->Entry(MongoLog::Local, "V1495 fractional mode inactive");
+  }
+  return 0;
+}
+
+int V1495_TPC::BeforeSINStart() {
+  int ret = 0;
+  if (fFractionalModeActive) {
+    ret += WriteReg(fControlReg, 0x1);
+    ret += WriteReg(fVetoOffMSBReg, fVetoOff_clk >> 32);
+    ret += WriteReg(fVetoOffLSBReg, fVetoOff_clk & 0xFFFFFFFF);
+    ret += WriteReg(fVetoOnMSBReg, fVetoOn_clk >> 32);
+    ret += WriteReg(fVetoOnLSBReg, fVetoOn_clk & 0xFFFFFFFF);
+  } else {
+    ret = WriteReg(fControlReg, 0x0);
+  }
+  return ret;
+}
+
+int V1495_TPC::AfterSINStop() {
+  return WriteReg(fControlReg, 0x0);
+}

--- a/V1495_tpc.hh
+++ b/V1495_tpc.hh
@@ -1,0 +1,25 @@
+#ifndef _V1495_TPC_HH_
+#define _V1495_TPC_HH_
+
+#include "V1495.hh"
+
+class V1495_TPC : public V1495 {
+  public:
+    V1495_TPC(std::shared_ptr<MongoLog>&, std::shared_ptr<Options>&, int, int, unsigned);
+    virtual ~V1495_TPC();
+    virtual int Init(std::map<std::string, int>&);
+    virtual int BeforeSINStart();
+    virtual int AfterSINStop();
+
+  private:
+    const uint32_t fControlReg
+    const uint32_t fVetoOffMSBReg;
+    const uint32_t fVetoOffLSBReg;
+    const uint32_t fVetoOnMSBReg;
+    const uint32_t fVetoOnLSBReg;
+
+    int fFractionalModeActive;
+    long fVetoOn_clk, fVetoOff_clk;
+};
+
+#endif // _V1495_TPC_HH_ defined


### PR DESCRIPTION
Given the considerable potential power of the V1495, having the only programming options be a few registers written during the arming sequence is a significant limitation. This PR adds several new functions to the base V1495, allowing for a subclass to do actions immediately on either side of the S-IN signal at the start and end of a run. These functions are very clearly labeled:
- `V1495::Arm(std::map<std::string, int>&)` provides the opportunity for a subclass to do any necessary setup
- `V1495::BeforeSINStart()`
- `V1495::AfterSINStart()`
- `V1495::BeforeSINStop()`
- `V1495::AfterSINStop()`